### PR TITLE
Fix TypeScript errors in App.tsx and useLibOpenMPT.ts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -65,7 +65,7 @@ function App() {
     toggleAudioEngine,
     status,
     syncDebug,
-    analyserNode
+    analyserNode,
   } = useLibOpenMPT(volume);
 
   // Media Overlay State
@@ -122,7 +122,6 @@ function App() {
         onViewModeToggle={() => setViewMode(viewMode === 'device' ? 'wall' : 'device')}
         onExitStudio={() => setIs3DMode(false)}
         dimFactor={dimFactor}
-        analyserNode={analyserNode}
         headerContent={
           <div className="scale-75 origin-top-left">
          <Header status={status} />

--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -245,8 +245,8 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
        // Interpolate/Predict row fraction?
        // For now, raw row is better than nothing.
        // We can use the timestamp of the last message vs current time to smooth it?
-       const now = audioContextRef.current?.currentTime || 0;
-       const dt = now - lastWorkletUpdateRef.current;
+
+
        // We could extrapolate if we knew speed... but row jumping is safer for now.
     } else {
        // Main thread module (ScriptProcessor)


### PR DESCRIPTION
- Removed redundant `analyserNode` prop from `Studio3D` usage in `App.tsx` as it is not defined in `Studio3DProps`.
- Removed unused variable `dt` in `hooks/useLibOpenMPT.ts`.

---
*PR created automatically by Jules for task [1460741675445590447](https://jules.google.com/task/1460741675445590447) started by @ford442*