### PR TITLE
Fix shader v0.45 circle cutoff at bottom

### DIFF
--- a/shaders/patternv0.45.wgsl
+++ b/shaders/patternv0.45.wgsl
@@ -79,7 +79,7 @@ fn vs(@builtin(vertex_index) vertexIndex: u32, @builtin(instance_index) instance
   let center = vec2<f32>(uniforms.canvasW * 0.5, uniforms.canvasH * 0.5);
   let minDim = min(uniforms.canvasW, uniforms.canvasH);
 
-  let maxRadius = minDim * 0.40; // Reduced from 0.45 to make room for buttons
+  let maxRadius = minDim * 0.35; // Fits within gridBottom (0.85) to prevent bottom cutoff
   let minRadius = minDim * 0.15;
   let ringDepth = (maxRadius - minRadius) / f32(numChannels);
 


### PR DESCRIPTION
## Summary
Fixed the circular visualization in shader v0.45 being clipped at the bottom by the UI control panel.

## Root Cause
The `maxRadius` was set to 0.40 (40% of canvas dimension), causing the circle to extend beyond the `gridBottom` boundary (0.85, or 85% of canvas height).

**Math:**
- Canvas: 1024×1024
- Circle center: (512, 512)
- Old maxRadius: 0.40 × 1024 = 409.6px → circle extends to y=921.6
- gridBottom cutoff: 0.85 × 1024 = 870.4
- **Result:** ~51px of the circle was clipped

## Fix
Reduced `maxRadius` from 0.40 to 0.35:
- New maxRadius: 0.35 × 1024 = 358.4px → circle extends to y=870.4
- Circle now perfectly aligns with the gridBottom boundary
- No clipping at the bottom

## Testing
- [x] Shader compiles without errors
- [ ] Visual verification: bottom of circle should now be fully visible without clipping
- [ ] No regression: circle visualization should remain visually centered