### PR TITLE
Remove registerProcessor hack and pass memory securely via options

### DIFF
--- a/cpp/pre.js
+++ b/cpp/pre.js
@@ -16,27 +16,6 @@ globalThis.clearTimeout = function() {};
 // Ensure Module exists
 if (typeof Module === 'undefined') Module = {};
 
-// Wrap registerProcessor so we can intercept processor options and
-// inject a pre‑allocated WASM.Memory object.  The React main thread
-// will create the memory and pass it via `processorOptions.memory`.
-// This hack runs early so that when the generated glue later calls
-// registerProcessor we can grab the options.
-(function() {
-    if (typeof registerProcessor !== 'function') return;
-    const orig = registerProcessor;
-    registerProcessor = function(name, ctor) {
-        class WrappedProcessor extends ctor {
-            constructor(options) {
-                if (options && options.processorOptions && options.processorOptions.memory) {
-                    Module['wasmMemory'] = options.processorOptions.memory;
-                }
-                super(options);
-            }
-        }
-        return orig(name, WrappedProcessor);
-    };
-})();
-
 // Configure module locator for WASM files served from /xm-player/worklets/
 Module['locateFile'] = function(path, prefix) {
     // In production, files are served from the base URL + worklets/

--- a/public/worklets/openmpt-worklet.js
+++ b/public/worklets/openmpt-worklet.js
@@ -11,6 +11,12 @@ function error(...args) { console.error('[Worklet]', ...args); }
 class XMPlayerProcessor extends AudioWorkletProcessor {
   constructor(options) {
     super(options);
+    // Provide Emscripten with the shared WASM Memory BEFORE the script loads
+    if (options && options.processorOptions && options.processorOptions.memory) {
+      globalThis.Module = globalThis.Module || {};
+      globalThis.Module['wasmMemory'] = options.processorOptions.memory;
+    }
+
     this.modulePtr = 0;
     this.leftBufPtr = 0;
     this.rightBufPtr = 0;


### PR DESCRIPTION
This PR refactors the initialization of `wasmMemory` in the `openmpt-worklet`. 

### Changes
* **`cpp/pre.js`**: Removed the global override of `registerProcessor`, which was originally added to intercept and set Emscripten's `Module['wasmMemory']` during Web Audio node initialization.
* **`public/worklets/openmpt-worklet.js`**: Replaced the global hack by formally extracting `options.processorOptions.memory` within the `XMPlayerProcessor` constructor and explicitly setting it on `globalThis.Module['wasmMemory']` right before launching the dynamic import for the Emscripten WASM binary.

These changes provide a formal, reliable sequence to bind `processorOptions.memory` to the `AudioWorkletNode`, avoiding fragile global wrappers and matching modern Emscripten workflows.

---
*PR created automatically by Jules for task [15599222733143537748](https://jules.google.com/task/15599222733143537748) started by @ford442*