### PR TITLE
Fix WebGL2 overlay coordinate alignment with WebGPU shader steps

### DIFF
--- a/hooks/useWebGLOverlay.ts
+++ b/hooks/useWebGLOverlay.ts
@@ -172,8 +172,18 @@ export function useWebGLOverlay(
         int trackIndex = id % int(u_cols);
         int stepIndex  = id / int(u_cols);
 
-        // Fetch cell data (packedA, packedB)
-        uvec2 cellData = texelFetch(u_cellData, ivec2(trackIndex, stepIndex), 0).rg;
+        // Page-aware cell data fetch.
+        // Horizontal layouts page through the pattern (32 or 64 steps per page);
+        // circular layouts show all rows directly but must clamp to valid range.
+        int actualRow;
+        if (u_layoutMode == 2 || u_layoutMode == 3) {
+            float stepsPerPageH = (u_layoutMode == 3) ? 64.0 : 32.0;
+            int pageStart = int(floor(u_playhead / stepsPerPageH) * stepsPerPageH);
+            actualRow = clamp(pageStart + stepIndex, 0, int(u_rows) - 1);
+        } else {
+            actualRow = clamp(stepIndex, 0, int(u_rows) - 1);
+        }
+        uvec2 cellData = texelFetch(u_cellData, ivec2(trackIndex, actualRow), 0).rg;
         v_cell = cellData;
 
         // Fetch channel state (2 rows)

--- a/utils/geometryConstants.ts
+++ b/utils/geometryConstants.ts
@@ -54,13 +54,12 @@ export function calculateCapScale(cellW: number, cellH: number, pixelRatio: numb
 
 // Determine layout mode from shader filename
 export function getLayoutModeFromShader(shaderFile: string): LayoutMode {
-  if (shaderFile.includes('v0.39') || shaderFile.includes('v0.40') || 
-      shaderFile.includes('v0.42') || shaderFile.includes('v0.43') ||
-      shaderFile.includes('v0.44')) {
+  if (shaderFile.includes('v0.39') || shaderFile.includes('v0.40') ||
+      shaderFile.includes('v0.43') || shaderFile.includes('v0.44')) {
     return LAYOUT_MODES.HORIZONTAL_32;
   }
-  
-  if (shaderFile.includes('v0.45') || shaderFile.includes('v0.46') ||
+
+  if (shaderFile.includes('v0.42') || shaderFile.includes('v0.45') || shaderFile.includes('v0.46') ||
       shaderFile.includes('v0.47') || shaderFile.includes('v0.48') ||
       shaderFile.includes('v0.49')) {
     return LAYOUT_MODES.CIRCULAR;


### PR DESCRIPTION
## Summary

- **v0.42 layout mode mismatch fixed**: `getLayoutModeFromShader()` was returning `HORIZONTAL_32` for `patternv0.42.wgsl`, which is a circular ring shader. Since v0.42 is in `WEBGL_HYBRID_SHADERS`, the WebGL overlay was rendering lens caps in horizontal grid positions on top of a circular WGSL background — complete positional mismatch. v0.42 is now correctly mapped to `CIRCULAR`.

- **WebGL cell data page alignment fixed**: The vertex shader's `texelFetch` previously always read texture rows 0–31 (`stepIndex = gl_InstanceID / cols`, capped at 31). For horizontal shaders (v0.39, v0.40), when the playhead advances past row 31, the WGSL background shows the next page (rows 32–63 at visual positions 0–31) but the WebGL caps were still showing note data from rows 0–31 — causing cap colors and trigger flashes to desync from the underlying cells. The fetch is now offset by `pageStart = floor(playhead / stepsPerPage) * stepsPerPage`. For circular layouts, `stepIndex` is clamped to `[0, numRows-1]` to prevent `CLAMP_TO_EDGE` artifacts when the pattern has fewer than 64 rows.

## Test plan

- [ ] Load a MOD file and select `patternv0.42.wgsl` — WebGL caps should appear on the circular rings, not as a misplaced horizontal row
- [ ] Select `patternv0.39.wgsl` or `patternv0.40.wgsl`, play past row 31 — cap colors/triggers should match the cells visible in the current page
- [ ] Select `patternv0.46.wgsl` (circular, was already correct) — no visual regression
- [ ] `npm run typecheck` reports no new errors (pre-existing @types/react issues are unrelated)

https://claude.ai/code/session_01W4CjWwSWN3bAWCYyMkrPw3