### PR TITLE
Add 32/64 step-length toggle to v0.21, v0.39, v0.40

### DIFF
--- a/components/PatternDisplay.tsx
+++ b/components/PatternDisplay.tsx
@@ -91,6 +91,7 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
   const [webgpuAvailable, setWebgpuAvailable] = useState(true);
   const [localTime, setLocalTime] = useState(0);
   const [invertChannels, setInvertChannels] = useState(false);
+  const [stepsLength, setStepsLength] = useState<32 | 64>(32);
   const [clickedButton, setClickedButton] = useState<number>(0);
   const clickTimeoutRef = useRef<number | null>(null);
   const animationFrameRef = useRef<number>();
@@ -119,6 +120,13 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
     if (shaderFile.includes('v0.25') || shaderFile.includes('v0.30') || shaderFile.includes('v0.35')) return { width: 1024, height: 1024 };
     return { width: Math.max(800, numChannels * cellWidth), height: 600 };
   }, [shaderFile, isHorizontal, numChannels, cellWidth]);
+
+  // Reset step length when switching to a shader that doesn't support it
+  useEffect(() => {
+    if (!shaderFile.includes('v0.21') && !shaderFile.includes('v0.39') && !shaderFile.includes('v0.40')) {
+      setStepsLength(32);
+    }
+  }, [shaderFile]);
 
   // Track video source changes
   useEffect(() => {
@@ -213,6 +221,7 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
     localTime, isHorizontal, externalVideoSource,
     canvasMetrics,
     colorPalette,
+    stepsLength,
     ...(totalRows !== undefined ? { totalRows } : {}),
     ...(playbackStateRef ? { playbackStateRef } : {}),
   });
@@ -224,6 +233,7 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
     localTime, isHorizontal, externalVideoSource,
     canvasMetrics,
     colorPalette,
+    stepsLength,
     ...(totalRows !== undefined ? { totalRows } : {}),
     ...(playbackStateRef ? { playbackStateRef } : {}),
   };
@@ -232,7 +242,7 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
   const { drawWebGL } = useWebGLOverlay(glCanvasRef, {
     shaderFile, matrix, padTopChannel, isOverlayActive,
     invertChannels, playheadRow, cellWidth, cellHeight,
-    channels, bloomIntensity,
+    channels, bloomIntensity, stepsLength,
     ...(playbackStateRef ? { playbackStateRef } : {}),
   }, setDebugInfo);
 
@@ -368,6 +378,15 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
           className="absolute top-2 left-12 px-2 py-1 bg-[#222] text-xs font-mono text-gray-400 border border-[#444] rounded hover:bg-[#333] hover:text-white transition-colors"
         >
           {invertChannels ? '[INNER LOW]' : '[OUTER LOW]'}
+        </button>
+      )}
+
+      {(shaderFile.includes('v0.21') || shaderFile.includes('v0.39') || shaderFile.includes('v0.40')) && (
+        <button
+          onClick={() => setStepsLength(s => s === 32 ? 64 : 32)}
+          className="absolute top-2 left-36 px-2 py-1 bg-[#222] text-xs font-mono text-gray-400 border border-[#444] rounded hover:bg-[#333] hover:text-white transition-colors"
+        >
+          [{stepsLength} STEPS]
         </button>
       )}
 

--- a/hooks/useWebGLOverlay.ts
+++ b/hooks/useWebGLOverlay.ts
@@ -47,6 +47,7 @@ export interface WebGLOverlayParams {
   channels?: ChannelShadowState[];
   bloomIntensity?: number;
   playbackStateRef?: React.MutableRefObject<PlaybackState>;
+  stepsLength?: number;
 }
 
 type DebugInfo = {
@@ -995,8 +996,8 @@ export function useWebGLOverlay(
 
       // Override layout for v0.21 (it's horizontal but not in getLayoutModeFromShader)
       let layoutMode = getLayoutModeFromShader(p.shaderFile);
-      if (p.shaderFile.includes('v0.21')) {
-        layoutMode = LAYOUT_MODES.HORIZONTAL_32;
+      if (p.shaderFile.includes('v0.21') || p.shaderFile.includes('v0.39') || p.shaderFile.includes('v0.40')) {
+        layoutMode = p.stepsLength === 64 ? LAYOUT_MODES.HORIZONTAL_64 : LAYOUT_MODES.HORIZONTAL_32;
       }
       const channelCount = cols;
 

--- a/hooks/useWebGPURender.ts
+++ b/hooks/useWebGPURender.ts
@@ -77,6 +77,7 @@ export interface WebGPURenderParams {
   canvasMetrics: { width: number; height: number };
   totalRows?: number;
   colorPalette?: number;
+  stepsLength?: number;
 }
 
 export function useWebGPURender(
@@ -484,11 +485,12 @@ export function useWebGPURender(
 
       let effectiveCellW = p.cellWidth;
       let effectiveCellH = p.cellHeight;
+      const stepsCount = p.stepsLength ?? 32;
       if (shaderFile.includes('v0.21') || shaderFile.includes('v0.40') || shaderFile.includes('v0.43') || shaderFile.includes('v0.44') || shaderFile.includes('v0.45') || shaderFile.includes('v0.46') || shaderFile.includes('v0.47') || shaderFile.includes('v0.48') || shaderFile.includes('v0.49') || shaderFile.includes('v0.50')) {
-        effectiveCellW = (GRID_RECT.w * actualCanvasW) / 32.0;
+        effectiveCellW = (GRID_RECT.w * actualCanvasW) / stepsCount;
         effectiveCellH = (GRID_RECT.h * actualCanvasH) / numChannels;
       } else if (shaderFile.includes('v0.39')) {
-        effectiveCellW = actualCanvasW / 32.0;
+        effectiveCellW = actualCanvasW / stepsCount;
         effectiveCellH = actualCanvasH / numChannels;
       }
 
@@ -517,6 +519,7 @@ export function useWebGPURender(
         innerRadius,
         outerRadius,
         colorPalette: p.colorPalette ?? 0,
+        stepsLength: p.stepsLength ?? 32,
         gridRect: GRID_RECT,
       }, uniformUintRef.current, uniformFloatRef.current);
       device.queue.writeBuffer(uniformBufferRef.current, 0, uniformBufferDataRef.current, 0, uniformByteLength);

--- a/public/shaders/patternv0.21.wgsl
+++ b/public/shaders/patternv0.21.wgsl
@@ -24,6 +24,7 @@ struct Uniforms {
   invertChannels: u32,
   dimFactor: f32,
   gridRect: vec4<f32>,  // x, y, w, h (normalized)
+  stepsLength: u32,     // 32 or 64 steps visible per page
 };
 
 @group(0) @binding(0) var<storage, read> cells: array<u32>;
@@ -59,7 +60,7 @@ fn vs(@builtin(vertex_index) vertexIndex: u32, @builtin(instance_index) instance
   // Horizontal Layout: X = Row (Time), Y = Channel
   // Static Paged Grid: We only render active page of 32 steps.
   
-  let stepsPerPage = 32.0;
+  let stepsPerPage = select(32.0, f32(uniforms.stepsLength), uniforms.stepsLength >= 32u);
   let pageStart = floor(f32(uniforms.playheadRow) / stepsPerPage) * stepsPerPage;
   
   // Calculate row local to current page (0..31)

--- a/public/shaders/patternv0.39.wgsl
+++ b/public/shaders/patternv0.39.wgsl
@@ -25,6 +25,7 @@ struct Uniforms {
   invertChannels: u32,
   dimFactor: f32,
   gridRect: vec4<f32>,
+  stepsLength: u32,     // 32 or 64 steps visible per page
 };
 
 @group(0) @binding(0) var<storage, read> cells: array<u32>;
@@ -59,7 +60,7 @@ fn vs(@builtin(vertex_index) vertexIndex: u32, @builtin(instance_index) instance
   // Horizontal Layout: X = Row (Time), Y = Channel
   // Static Paged Grid: We only render active page of 32 steps.
   
-  let stepsPerPage = 32.0;
+  let stepsPerPage = select(32.0, f32(uniforms.stepsLength), uniforms.stepsLength >= 32u);
   let pageStart = floor(uniforms.playheadRow / stepsPerPage) * stepsPerPage;
   
   // Calculate row local to current page (0..31)

--- a/public/shaders/patternv0.40.wgsl
+++ b/public/shaders/patternv0.40.wgsl
@@ -23,7 +23,7 @@ struct Uniforms {
   invertChannels: u32,
   dimFactor: f32,
   gridRect: vec4<f32>,
-  colorPalette: u32,
+  stepsLength: u32,     // 32 or 64 steps visible per page
 };
 
 @group(0) @binding(0) var<storage, read> cells: array<u32>;
@@ -55,7 +55,7 @@ fn vs(@builtin(vertex_index) vertexIndex: u32, @builtin(instance_index) instance
   let row = instanceIndex / numChannels;
   let channel = instanceIndex % numChannels;
 
-  let stepsPerPage = 32.0;
+  let stepsPerPage = select(32.0, f32(uniforms.stepsLength), uniforms.stepsLength >= 32u);
   // Use floor on the float, then multiply to get the page start
   let pageStart = floor(uniforms.playheadRow / stepsPerPage) * stepsPerPage;
   let localRow = f32(row) - pageStart;

--- a/shaders/patternv0.21.wgsl
+++ b/shaders/patternv0.21.wgsl
@@ -24,6 +24,7 @@ struct Uniforms {
   invertChannels: u32,
   dimFactor: f32,
   gridRect: vec4<f32>,  // x, y, w, h (normalized)
+  stepsLength: u32,     // 32 or 64 steps visible per page
 };
 
 @group(0) @binding(0) var<storage, read> cells: array<u32>;
@@ -59,7 +60,7 @@ fn vs(@builtin(vertex_index) vertexIndex: u32, @builtin(instance_index) instance
   // Horizontal Layout: X = Row (Time), Y = Channel
   // Static Paged Grid: We only render active page of 32 steps.
   
-  let stepsPerPage = 32.0;
+  let stepsPerPage = select(32.0, f32(uniforms.stepsLength), uniforms.stepsLength >= 32u);
   let pageStart = floor(f32(uniforms.playheadRow) / stepsPerPage) * stepsPerPage;
   
   // Calculate row local to current page (0..31)

--- a/shaders/patternv0.39.wgsl
+++ b/shaders/patternv0.39.wgsl
@@ -25,6 +25,7 @@ struct Uniforms {
   invertChannels: u32,
   dimFactor: f32,
   gridRect: vec4<f32>,
+  stepsLength: u32,     // 32 or 64 steps visible per page
 };
 
 @group(0) @binding(0) var<storage, read> cells: array<u32>;
@@ -59,7 +60,7 @@ fn vs(@builtin(vertex_index) vertexIndex: u32, @builtin(instance_index) instance
   // Horizontal Layout: X = Row (Time), Y = Channel
   // Static Paged Grid: We only render active page of 32 steps.
   
-  let stepsPerPage = 32.0;
+  let stepsPerPage = select(32.0, f32(uniforms.stepsLength), uniforms.stepsLength >= 32u);
   let pageStart = floor(uniforms.playheadRow / stepsPerPage) * stepsPerPage;
   
   // Calculate row local to current page (0..31)

--- a/shaders/patternv0.40.wgsl
+++ b/shaders/patternv0.40.wgsl
@@ -23,7 +23,7 @@ struct Uniforms {
   invertChannels: u32,
   dimFactor: f32,
   gridRect: vec4<f32>,
-  colorPalette: u32,
+  stepsLength: u32,     // 32 or 64 steps visible per page
 };
 
 @group(0) @binding(0) var<storage, read> cells: array<u32>;
@@ -55,7 +55,7 @@ fn vs(@builtin(vertex_index) vertexIndex: u32, @builtin(instance_index) instance
   let row = instanceIndex / numChannels;
   let channel = instanceIndex % numChannels;
 
-  let stepsPerPage = 32.0;
+  let stepsPerPage = select(32.0, f32(uniforms.stepsLength), uniforms.stepsLength >= 32u);
   // Use floor on the float, then multiply to get the page start
   let pageStart = floor(uniforms.playheadRow / stepsPerPage) * stepsPerPage;
   let localRow = f32(row) - pageStart;

--- a/utils/gpuPacking.ts
+++ b/utils/gpuPacking.ts
@@ -57,6 +57,7 @@ export const fillUniformPayload = (
     innerRadius?: number;
     outerRadius?: number;
     colorPalette?: number;
+    stepsLength?: number;
     analyserNode?: AnalyserNode | null;
     gridRect?: { x: number; y: number; w: number; h: number };
   },
@@ -92,7 +93,7 @@ export const fillUniformPayload = (
     float[21] = params.gridRect?.y ?? GRID_RECT.y;
     float[22] = params.gridRect?.w ?? GRID_RECT.w;
     float[23] = params.gridRect?.h ?? GRID_RECT.h;
-    uint[24] = Math.max(0, params.colorPalette ?? 0) >>> 0;
+    uint[24] = Math.max(0, params.stepsLength ?? params.colorPalette ?? 0) >>> 0;
     float[25] = params.innerRadius ?? 0.0;
     float[26] = params.outerRadius ?? 0.0;
     return 108;


### PR DESCRIPTION
## Summary

- Adds a runtime 32/64 step-length toggle to the horizontal shaders v0.21, v0.39, and v0.40, replacing the need to switch to the separate v0.43 (32-step) or v0.44 (64-step) full-screen shaders
- v0.43 and v0.44 remain in the project but are no longer necessary for step-count variation

## Changes

**WGSL shaders** (`patternv0.21`, `patternv0.39`, `patternv0.40` — both `/shaders/` and `/public/shaders/`):
- Added `stepsLength: u32` uniform field (after `gridRect` in v0.21/v0.39; replaces unused `colorPalette` in v0.40)
- Vertex shader now reads `stepsPerPage` from the uniform instead of hardcoding `32.0`; defaults to 32 when value < 32

**`utils/gpuPacking.ts`**:
- Added `stepsLength?: number` to `fillUniformPayload` params; written at `uint[24]` (takes priority over `colorPalette`)

**`hooks/useWebGPURender.ts`**:
- Added `stepsLength?: number` to `WebGPURenderParams`
- `effectiveCellW` calculation now divides by `stepsCount` instead of hardcoded 32

**`hooks/useWebGLOverlay.ts`**:
- Added `stepsLength?: number` to `WebGLOverlayParams`
- Overlay selects `HORIZONTAL_32` or `HORIZONTAL_64` layout mode based on `stepsLength` for v0.21/v0.39/v0.40 (previously v0.21 was always hardcoded to 32)

**`components/PatternDisplay.tsx`**:
- Added `stepsLength` local state (32 | 64)
- Added `[32 STEPS]` / `[64 STEPS]` toggle button visible when v0.21, v0.39, or v0.40 is active
- Resets to 32 when switching to a different shader

## Test plan

- [ ] Load v0.21, v0.39, or v0.40 shader — confirm `[32 STEPS]` button appears
- [ ] Click button — grid switches to 64 columns, overlay caps resize accordingly
- [ ] Click again — returns to 32 columns
- [ ] Switch to another shader — step count resets and button disappears
- [ ] v0.43 and v0.44 still load and render correctly (unchanged)

https://claude.ai/code/session_01XaytRvBxzDEJBmw15qF6oy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaytRvBxzDEJBmw15qF6oy)_