### PR TITLE
TIMING FIX: Reset timing refs on stop

### DIFF
--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -474,6 +474,8 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     audioClockStartRef.current = 0;
     workletTimeAtStartRef.current = 0;
     driftAccumulatorRef.current = 0;
+    lastCorrectedTimeRef.current = 0;
+    lastWorkletUpdateRef.current = 0;
     pendingSeekRef.current = null;
     seekAcknowledgedRef.current = true;
 


### PR DESCRIPTION
Added resets for `lastCorrectedTimeRef` and `lastWorkletUpdateRef` in the stop function to ensure all timing state is completely cleared on stop. This is part of the TIMING FIX.

---
*PR created automatically by Jules for task [17667526822226397389](https://jules.google.com/task/17667526822226397389) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timing synchronization when stopping music playback to ensure accurate state for subsequent playback and UI synchronization actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->