### PR TITLE
chore: mark AUDIO-001 FIX as complete

### DIFF
--- a/hooks/useAudioGraph.ts
+++ b/hooks/useAudioGraph.ts
@@ -62,7 +62,7 @@ export interface AudioGraphConfig {
   WORKLET_URL:            string;
 }
 
-// AUDIO-001 FIX: Enhanced logging helper
+// AUDIO-001 FIX COMPLETE: Enhanced logging helper
 const logWorkletDiagnostics = (ctx: AudioContext, workletUrl: string) => {
   console.log('[WORKLET_DIAGNOSTICS]', {
     audioContextState: ctx.state,
@@ -75,7 +75,7 @@ const logWorkletDiagnostics = (ctx: AudioContext, workletUrl: string) => {
   });
 };
 
-// AUDIO-001 FIX: Centralized worklet URL from useWorkletLoader
+// AUDIO-001 FIX COMPLETE: Centralized worklet URL from useWorkletLoader
 const WORKLET_URL = getWorkletUrl();
 
 export async function startAudioPlayback(
@@ -112,7 +112,7 @@ export async function startAudioPlayback(
     const ctx = refs.audioContextRef.current;
     console.log('[PLAY] AudioContext state:', ctx.state);
     
-    // AUDIO-001 FIX: Log diagnostics
+    // AUDIO-001 FIX COMPLETE: Log diagnostics
     logWorkletDiagnostics(ctx, config.WORKLET_URL);
 
     if (ctx.state === 'suspended') {
@@ -270,7 +270,7 @@ export async function startAudioPlayback(
       console.log('[PLAY] Using AudioWorklet engine...');
 
       try {
-        // AUDIO-001 FIX: Enhanced worklet module loading with better error handling
+        // AUDIO-001 FIX COMPLETE: Enhanced worklet module loading with better error handling
         if (ctx.audioWorklet && !refs.workletLoadedRef.current) {
           // Use centralized WORKLET_URL for consistency
           const workletUrl = WORKLET_URL || config.WORKLET_URL;
@@ -282,7 +282,7 @@ export async function startAudioPlayback(
           console.log('[PLAY] ==================================================');
           
           try {
-            // AUDIO-001 FIX: Add timeout for worklet loading to detect hanging
+            // AUDIO-001 FIX COMPLETE: Add timeout for worklet loading to detect hanging
             const loadTimeout = new Promise<never>((_, reject) => {
               setTimeout(() => reject(new Error('Worklet module load timeout (10s)')), 10000);
             });
@@ -296,7 +296,7 @@ export async function startAudioPlayback(
             console.error('[PLAY] ❌ Failed to load AudioWorklet module:', loadError);
             console.error('[PLAY] URL attempted:', workletUrl);
             
-            // AUDIO-001 FIX: Provide helpful diagnostics for common issues
+            // AUDIO-001 FIX COMPLETE: Provide helpful diagnostics for common issues
             const errorMsg = (loadError as Error).message || 'Unknown error';
             
             // Check for 404 errors
@@ -343,7 +343,7 @@ export async function startAudioPlayback(
         }
         if (wasmMemory) processorOptions.memory = wasmMemory;
         
-        // AUDIO-001 FIX: Wrap node creation in try-catch for better diagnostics
+        // AUDIO-001 FIX COMPLETE: Wrap node creation in try-catch for better diagnostics
         let node: AudioWorkletNode;
         try {
           node = new AudioWorkletNode(ctx, 'openmpt-processor', {
@@ -512,7 +512,7 @@ export async function startAudioPlayback(
         console.error("[PLAY] Failed to create/load AudioWorkletNode:", e);
         refs.workletLoadedRef.current = false;
         
-        // AUDIO-001 FIX: Better error messages based on error type
+        // AUDIO-001 FIX COMPLETE: Better error messages based on error type
         const errorMsg = (e as Error).message || 'Unknown error';
         if (errorMsg.includes('timeout')) {
           callbacks.setStatus("Error: AudioWorklet load timeout (check network)");

--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -16,10 +16,10 @@ interface SyncDebugInfo {
 // Use Vite BASE_URL for correct resolution under subdirectory deployment
 const DEFAULT_MODULE_URL = `${import.meta.env.BASE_URL}4-mat_madness.mod`;
 
-// AUDIO-001 FIX: Use centralized worklet URL construction from useWorkletLoader
+// AUDIO-001 FIX COMPLETE: Use centralized worklet URL construction from useWorkletLoader
 const WORKLET_URL = getWorkletUrl();
 
-// AUDIO-001 FIX: Enhanced logging for diagnostics
+// AUDIO-001 FIX COMPLETE: Enhanced logging for diagnostics
 console.log('[AudioWorklet] Configuration:', {
   workletUrl: WORKLET_URL,
   viteBaseUrl: import.meta.env.BASE_URL,
@@ -59,10 +59,10 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
   const [restartPlayback, setRestartPlayback] = useState<boolean>(false);
   const [syncDebug, setSyncDebug] = useState<SyncDebugInfo>({ mode: "none", bufferMs: 0, driftMs: 0, row: 0, starvationCount: 0 });
   
-  // AUDIO-001 FIX: Track worklet load errors for UI feedback
+  // AUDIO-001 FIX COMPLETE: Track worklet load errors for UI feedback
   const [workletLoadError, setWorkletLoadError] = useState<string | null>(null);
   
-  // AUDIO-001 FIX: Initialize worklet loader with diagnostics
+  // AUDIO-001 FIX COMPLETE: Initialize worklet loader with diagnostics
   const { verifyWorkletFile, isAudioWorkletSupported: checkWorkletSupport } = useWorkletLoader({
     debug: true,
   });
@@ -575,7 +575,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
   // so processModuleData (which memoises over different deps) can call it without stale closure
   playRef.current = play;
 
-  // AUDIO-001 FIX: Enhanced toggle function with better engine state management
+  // AUDIO-001 FIX COMPLETE: Enhanced toggle function with better engine state management
   const toggleAudioEngine = useCallback(() => {
     // Cycle: native-worklet → worklet → native-worklet (if available)
     let newEngine: 'worklet' | 'native-worklet';
@@ -657,7 +657,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
         libopenmptRef.current = lib;
         setIsReady(true);
 
-        // AUDIO-001 FIX: Enhanced AudioWorklet support check with detailed diagnostics
+        // AUDIO-001 FIX COMPLETE: Enhanced AudioWorklet support check with detailed diagnostics
         console.log("[INIT] Testing AudioWorklet support...");
         try {
           const hasWorkletSupport = checkWorkletSupport();
@@ -668,7 +668,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
             userAgent: navigator.userAgent.substring(0, 50) + '...',
           });
 
-          // AUDIO-001 FIX: Verify the worklet file is accessible
+          // AUDIO-001 FIX COMPLETE: Verify the worklet file is accessible
           if (hasWorkletSupport) {
             const fileAccessible = await verifyWorkletFile();
             
@@ -794,7 +794,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     // PERFORMANCE OPTIMIZATION: Export ref for high-frequency updates
     // PatternDisplay reads directly from this to this ref - avoids React re-renders
     playbackStateRef,
-    // AUDIO-001 FIX: Export worklet diagnostics
+    // AUDIO-001 FIX COMPLETE: Export worklet diagnostics
     workletLoadError,
   };
 }

--- a/hooks/useWorkletLoader.ts
+++ b/hooks/useWorkletLoader.ts
@@ -1,7 +1,7 @@
 /**
  * useWorkletLoader.ts - AudioWorklet loading with proper Vite URL handling
  * 
- * AUDIO-001 FIX: This module provides robust worklet loading with:
+ * AUDIO-001 FIX COMPLETE: This module provides robust worklet loading with:
  * 1. Proper Vite asset URL construction using ?url imports
  * 2. Error handling and diagnostics for worklet initialization failures
  * 3. Retry logic with exponential backoff


### PR DESCRIPTION
This PR updates the comments associated with the AUDIO-001 fix to mark them as completed across `hooks/useLibOpenMPT.ts`, `hooks/useWorkletLoader.ts`, and `hooks/useAudioGraph.ts`. This was done per user request since the task was already completed but the comments remained, leading to repetitive issue tracking/flagging.

---
*PR created automatically by Jules for task [11858775848759876891](https://jules.google.com/task/11858775848759876891) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry logic with exponential backoff for audio worklet initialization
  * Enhanced diagnostics and error messages for audio playback troubleshooting

* **Bug Fixes**
  * Improved reliability of audio engine startup with centralized configuration handling
  * Better fallback behavior when audio worklet initialization encounters issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->