### PR TITLE
fix(audio): Use performance.now for seek timeout check

### DIFF
--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -326,9 +326,9 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
 
     // TIMING FIX: Check for pending seek acknowledgment
     if (pendingSeekRef.current && !seekAcknowledgedRef.current) {
-      const seekAge = audioCtx ? audioCtx.currentTime - pendingSeekRef.current.timestamp : 0;
+      const seekAgeMs = performance.now() - pendingSeekRef.current.timestamp;
       // If seek is older than 500ms, consider it acknowledged to prevent stuck state
-      if (seekAge > 0.5) {
+      if (seekAgeMs > 500) {
         seekAcknowledgedRef.current = true;
         pendingSeekRef.current = null;
       }
@@ -513,7 +513,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     pendingSeekRef.current = {
       order: targetOrder,
       row: targetRow,
-      timestamp: audioCtx ? audioCtx.currentTime : performance.now() / 1000
+      timestamp: performance.now()
     };
     seekAcknowledgedRef.current = false;
 

--- a/mod-player-shaders/useLibOpenMPT.ts
+++ b/mod-player-shaders/useLibOpenMPT.ts
@@ -254,8 +254,8 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     }
 
     if (pendingSeekRef.current && !seekAcknowledgedRef.current) {
-      const seekAge = audioCtx ? audioCtx.currentTime - pendingSeekRef.current.timestamp : 0;
-      if (seekAge > 0.5) { seekAcknowledgedRef.current = true; pendingSeekRef.current = null; }
+      const seekAgeMs = performance.now() - pendingSeekRef.current.timestamp;
+      if (seekAgeMs > 500) { seekAcknowledgedRef.current = true; pendingSeekRef.current = null; }
     }
 
     if (sequencerMatrix?.order !== order) {
@@ -388,7 +388,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     }
 
     const audioCtx = audioContextRef.current;
-    pendingSeekRef.current = { order: targetOrder, row: targetRow, timestamp: audioCtx ? audioCtx.currentTime : performance.now() / 1000 };
+    pendingSeekRef.current = { order: targetOrder, row: targetRow, timestamp: performance.now() };
     seekAcknowledgedRef.current = false;
     lib._openmpt_module_set_position_order_row(modPtr, targetOrder, targetRow);
     workletOrderRef.current = targetOrder;


### PR DESCRIPTION
This PR fixes an issue where the pending seek would not be cleared correctly when there's no `audioContext` due to a mismatch between how `timestamp` is initially set (with `performance.now()`) and how `seekAge` is checked (calculating an age of `0`). It now consistently uses `performance.now()` for tracking seek age in milliseconds.

---
*PR created automatically by Jules for task [10720480104993521433](https://jules.google.com/task/10720480104993521433) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added diagnostic information during audio engine startup for improved troubleshooting and error detection

* **Bug Fixes**
  * Improved audio seek timing and synchronization for more reliable and stable playback
  * Enhanced error detection and status reporting to better communicate audio initialization issues
  * Refined drift correction and timestamp handling to reduce timing inconsistencies and playback issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->