### PR TITLE
fix: Apply true hardware audio drift correction

### DIFF
--- a/hooks/useAudioGraph.ts
+++ b/hooks/useAudioGraph.ts
@@ -123,7 +123,7 @@ export async function startAudioPlayback(
 
     // TIMING FIX: Initialize audio clock reference
     refs.audioClockStartRef.current = ctx.currentTime;
-    refs.workletTimeAtStartRef.current = 0;
+    refs.workletTimeAtStartRef.current = refs.workletTimeRef.current || 0;
     refs.driftAccumulatorRef.current = 0;
 
     // Setup common nodes

--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -299,17 +299,33 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
           rowFraction = Math.min(1, elapsedSinceWorkletUpdate * rowsPerSecond);
 
           // TIMING FIX: Apply drift correction
-          const expectedTime = workletTimeRef.current + elapsedSinceWorkletUpdate;
-          const drift = time - expectedTime;
+          // 'now' is audioCtx.currentTime (the hardware master clock)
+          const elapsedHardwareTime = now - audioClockStartRef.current;
+          const expectedTime = workletTimeAtStartRef.current + elapsedHardwareTime;
+
+          // The tracker's actual time (last known worklet time + extrapolated UI frame time)
+          const actualTrackerTime = workletTimeRef.current + elapsedSinceWorkletUpdate;
+
+          // True clock drift: positive means tracker is ahead, negative means tracker is lagging
+          const drift = actualTrackerTime - expectedTime;
+
+          // Accumulate the true drift (low-pass filter to smooth out micro-jitters)
           driftAccumulatorRef.current = driftAccumulatorRef.current * 0.9 + drift * 0.1;
 
-          // Update sync debug info
+          // Apply correction
           if (Math.abs(driftAccumulatorRef.current) > MAX_DRIFT_SECONDS) {
-            // Apply correction
-            time = expectedTime + driftAccumulatorRef.current * 0.5;
+            // A major desync occurred (tab backgrounded, CPU spike, etc.).
+            // Snap the UI to exactly where the hardware audio clock is.
+            time = expectedTime;
+
+            // Optionally reset the baselines here to prevent perpetual snapping
+            audioClockStartRef.current = now;
+            workletTimeAtStartRef.current = workletTimeRef.current;
+            driftAccumulatorRef.current = 0;
             lastCorrectedTimeRef.current = now;
           } else {
-            time = expectedTime;
+            // Normal operation: Smoothly subtract the drift so the UI aligns with the audio
+            time = actualTrackerTime - driftAccumulatorRef.current;
           }
         } else {
           // Worklet hasn't updated recently - use last known values
@@ -531,6 +547,10 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     // TIMING FIX: Reset drift accumulator on seek
     driftAccumulatorRef.current = 0;
     lastWorkletUpdateRef.current = audioCtx ? audioCtx.currentTime : 0;
+
+    // TIMING FIX: Reset baselines on seek to prevent massive drift calculation
+    audioClockStartRef.current = audioCtx ? audioCtx.currentTime : 0;
+    workletTimeAtStartRef.current = workletTimeRef.current;
 
     // Worklet update with acknowledgment tracking
     if (activeEngine === 'native-worklet' && nativeEngineRef.current) {

--- a/mod-player-shaders/hooks/useAudioGraph.ts
+++ b/mod-player-shaders/hooks/useAudioGraph.ts
@@ -301,7 +301,7 @@ export async function startAudioPlayback(refs, callbacks, config) {
     }
 
     audioClockStartRef.current = ctx.currentTime;
-    workletTimeAtStartRef.current = 0;
+    workletTimeAtStartRef.current = workletTimeRef.current || 0;
     driftAccumulatorRef.current = 0;
 
     // Setup audio nodes

--- a/mod-player-shaders/useLibOpenMPT.ts
+++ b/mod-player-shaders/useLibOpenMPT.ts
@@ -235,14 +235,19 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
         const elapsed = now - lastWorkletUpdateRef.current;
         if (elapsed < 0.1) {
           rowFraction = Math.min(1, elapsed * (currentBpm / 60 / 4));
-          const expectedTime = workletTimeRef.current + elapsed;
-          const drift = time - expectedTime;
+          const elapsedHardwareTime = now - audioClockStartRef.current;
+          const expectedTime = workletTimeAtStartRef.current + elapsedHardwareTime;
+          const actualTrackerTime = workletTimeRef.current + elapsed;
+          const drift = actualTrackerTime - expectedTime;
           driftAccumulatorRef.current = driftAccumulatorRef.current * 0.9 + drift * 0.1;
           if (Math.abs(driftAccumulatorRef.current) > MAX_DRIFT_SECONDS) {
-            time = expectedTime + driftAccumulatorRef.current * 0.5;
+            time = expectedTime;
+            audioClockStartRef.current = now;
+            workletTimeAtStartRef.current = workletTimeRef.current;
+            driftAccumulatorRef.current = 0;
             lastCorrectedTimeRef.current = now;
           } else {
-            time = expectedTime;
+            time = actualTrackerTime - driftAccumulatorRef.current;
           }
         }
       }
@@ -398,6 +403,8 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     setSequencerGlobalRow(step);
     driftAccumulatorRef.current = 0;
     lastWorkletUpdateRef.current = audioCtx ? audioCtx.currentTime : 0;
+    audioClockStartRef.current = audioCtx ? audioCtx.currentTime : 0;
+    workletTimeAtStartRef.current = workletTimeRef.current;
 
     if (activeEngine === 'native-worklet' && nativeEngineRef.current) {
       nativeEngineRef.current.seek(targetOrder, targetRow);


### PR DESCRIPTION
Replaces the flawed mathematical tautology used for measuring audio-to-worklet drift, which was previously computing a negative elapsed delta without comparing two separate clocks.

With this update, `audioCtx.currentTime` serves as the master baseline. When calculating drift, the player accurately measures the amount of time elapsed in the hardware against the time generated by the libopenmpt worklet. Should a significant discrepancy occur due to background tab throttling or an interruption, the UI playhead gracefully snaps to realign perfectly with the actual hardware clock. Seeking or play/pause actions seamlessly reset these baselines so playback resumes accurately without massive drift miscalculation.

---
*PR created automatically by Jules for task [11984636583755044158](https://jules.google.com/task/11984636583755044158) started by @ford442*