### PR TITLE
fix(audio): acknowledge seek from AudioWorklet to main thread

### DIFF
--- a/hooks/useAudioGraph.ts
+++ b/hooks/useAudioGraph.ts
@@ -485,6 +485,11 @@ export async function startAudioPlayback(
             // TIMING FIX: Worklet acknowledged seek
             refs.seekAcknowledgedRef.current = true;
             refs.pendingSeekRef.current = null;
+            console.log('[seekAck] Received from worklet', {
+              order: e.data.order,
+              row: e.data.row,
+              timestamp: e.data.timestamp
+            });
           }
         };
 

--- a/mod-player-shaders/openmpt-worklet.js
+++ b/mod-player-shaders/openmpt-worklet.js
@@ -139,8 +139,18 @@ class XMPlayerProcessor extends AudioWorkletProcessor {
           this.lib._openmpt_module_set_position_order_row(
             this.modulePtr, e.data.order, e.data.row
           );
+
+          // TIMING FIX: Acknowledge seek back to main thread
+          this.port.postMessage({
+            type: 'seekAck',
+            order: e.data.order,
+            row: e.data.row,
+            timestamp: e.data.timestamp || currentTime
+          });
         } else {
           error('Cannot seek: module not loaded');
+          // Still send ack so we don't hang
+          this.port.postMessage({ type: 'seekAck', success: false });
         }
       } else if (!type && moduleData) {
         // Legacy fallback

--- a/public/worklets/openmpt-worklet.js
+++ b/public/worklets/openmpt-worklet.js
@@ -40,8 +40,18 @@ class XMPlayerProcessor extends AudioWorkletProcessor {
           this.lib._openmpt_module_set_position_order_row(
             this.modulePtr, e.data.order, e.data.row
           );
+
+          // TIMING FIX: Acknowledge seek back to main thread
+          this.port.postMessage({
+            type: 'seekAck',
+            order: e.data.order,
+            row: e.data.row,
+            timestamp: e.data.timestamp || currentTime
+          });
         } else {
           error('Cannot seek: module not loaded');
+          // Still send ack so we don't hang
+          this.port.postMessage({ type: 'seekAck', success: false });
         }
       } else if (!type && moduleData) {
         // Legacy fallback


### PR DESCRIPTION
TIMING FIX: Added missing 'seekAck' message from openmpt-worklet to the main thread.
Previously, the main thread was waiting for a seek acknowledgment from the worklet 
to clear its pendingSeekRef and prevent a 500ms timeout. The worklet was performing
the seek but silently finishing without informing the main thread. 

This commit ensures both worklet copies (public and mod-player-shaders) properly
post a 'seekAck' message back, containing the target order, row, and timestamp
for correlation.

---
*PR created automatically by Jules for task [6871283909912888515](https://jules.google.com/task/6871283909912888515) started by @ford442*