### PR TITLE
TIMING FIX: Reset timing refs on stop

### DIFF
--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -474,8 +474,23 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     audioClockStartRef.current = 0;
     workletTimeAtStartRef.current = 0;
     driftAccumulatorRef.current = 0;
+    lastCorrectedTimeRef.current = 0;
     pendingSeekRef.current = null;
     seekAcknowledgedRef.current = true;
+
+    // Reset worklet update timestamp to prevent interpolation jumps and monotonicity locks
+    const audioCtx = audioContextRef.current;
+    lastWorkletUpdateRef.current = audioCtx ? audioCtx.currentTime : (performance.now() / 1000);
+
+    // Snap UI cleanly to zero immediately on stop
+    workletTimeRef.current = 0;
+    workletOrderRef.current = 0;
+    workletRowRef.current = 0;
+
+    console.log('[stopMusic] Timing refs reset', {
+      lastWorkletUpdate: lastWorkletUpdateRef.current,
+      lastCorrected: lastCorrectedTimeRef.current
+    });
 
     if (destroy && currentModulePtr.current !== 0 && libopenmptRef.current) {
       libopenmptRef.current._openmpt_module_destroy(currentModulePtr.current);


### PR DESCRIPTION
I've implemented the changes to `hooks/useLibOpenMPT.ts` in the `stopMusic` callback. 

The `TIMING FIX: Reset timing refs on stop` block has been updated to reset all necessary timing references cleanly to avoid issues such as interpolation jumps and monotonicity locks upon track restarts:
- `lastCorrectedTimeRef.current = 0`
- `lastWorkletUpdateRef.current = audioCtx ? audioCtx.currentTime : (performance.now() / 1000)`
- `workletTimeRef.current = 0`
- `workletOrderRef.current = 0`
- `workletRowRef.current = 0`

Tests were run successfully with `npm run build` and `npm run typecheck`.

---
*PR created automatically by Jules for task [13001314065871460776](https://jules.google.com/task/13001314065871460776) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed audio playback issues when stopping music, preventing position jumps and interpolation glitches. Improved timing state management ensures smoother, more predictable audio behavior during playback transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->