### PR TITLE
fix(timing): remove playbackRowFraction from updateUI dependency array

### DIFF
--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -368,7 +368,8 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     setSequencerGlobalRow(globalRow + row);
 
     // TIMING FIX: Smooth row fraction for visual display
-    const smoothedRowFraction = rowFraction * ROW_INTERPOLATION_SMOOTHING + (playbackRowFraction * (1 - ROW_INTERPOLATION_SMOOTHING));
+    const prevFraction = playbackStateRef.current.playheadRow % 1;
+    const smoothedRowFraction = rowFraction * ROW_INTERPOLATION_SMOOTHING + (prevFraction * (1 - ROW_INTERPOLATION_SMOOTHING));
     setPlaybackRowFraction(smoothedRowFraction);
 
     // Compute note ages for hardware choke in shader (only update React state when integer ages change)
@@ -446,7 +447,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
 
     lastUpdateTimeRef.current = performance.now() / 1000;
     animationFrameHandle.current = requestAnimationFrame(updateUI);
-  }, [isPlaying, activeEngine, sequencerMatrix, kickTrigger, grooveAmount, playbackRowFraction]);
+  }, [isPlaying, activeEngine, sequencerMatrix, kickTrigger, grooveAmount]);
 
   // Keep updateUIRef always pointing to the latest updateUI so
   // startAudioPlayback can schedule the most current callback.

--- a/mod-player-shaders/useLibOpenMPT.ts
+++ b/mod-player-shaders/useLibOpenMPT.ts
@@ -276,7 +276,8 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     for (let i = 0; i < order; i++) globalRow += patternMatricesRef.current[i]?.numRows || 64;
     setSequencerGlobalRow(globalRow + row);
 
-    const smoothedRowFraction = rowFraction * ROW_INTERPOLATION_SMOOTHING + (playbackRowFraction * (1 - ROW_INTERPOLATION_SMOOTHING));
+    const prevFraction = playbackStateRef.current.playheadRow % 1;
+    const smoothedRowFraction = rowFraction * ROW_INTERPOLATION_SMOOTHING + (prevFraction * (1 - ROW_INTERPOLATION_SMOOTHING));
     setPlaybackRowFraction(smoothedRowFraction);
 
     const beatPhaseValue = (time * 2) % 1;
@@ -298,7 +299,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
 
     lastUpdateTimeRef.current = performance.now() / 1000;
     animationFrameHandle.current = requestAnimationFrame(updateUI);
-  }, [isPlaying, activeEngine, sequencerMatrix, kickTrigger, grooveAmount, playbackRowFraction]);
+  }, [isPlaying, activeEngine, sequencerMatrix, kickTrigger, grooveAmount]);
 
   const stopMusic = useCallback((destroy: boolean = false) => {
     isPlayingRef.current = false;


### PR DESCRIPTION
This PR addresses a performance issue where the `updateUI` callback was being re-created on every animation frame because it depended on `playbackRowFraction` which it also updates. Instead of depending on the state variable, we now derive the previous fraction directly from the mutable `playbackStateRef.current.playheadRow`. 

Fixes applied to both `hooks/useLibOpenMPT.ts` and `mod-player-shaders/useLibOpenMPT.ts`.

---
*PR created automatically by Jules for task [10964793668250450687](https://jules.google.com/task/10964793668250450687) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal playback smoothing interpolation logic to use reference-based playhead tracking instead of state-based tracking, reducing unnecessary dependency coupling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->