### PR TITLE
fix(audio): AUDIO-001 Use centralized worklet URL construction

### DIFF
--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -3,7 +3,7 @@ import { LibOpenMPT, ModuleInfo, PatternMatrix, ChannelShadowState, PlaybackStat
 import { OpenMPTWorkletEngine } from '../audio-worklet/OpenMPTWorkletEngine';
 import { getPatternMatrix, computeNoteAges } from '../utils/patternExtractor';
 import { startAudioPlayback, AudioGraphRefs, AudioGraphCallbacks, AudioGraphConfig } from './useAudioGraph';
-import { useWorkletLoader, getWorkletUrl } from './useWorkletLoader';
+import { useWorkletLoader, getWorkletUrl, getNativeGlueUrl } from './useWorkletLoader';
 
 interface SyncDebugInfo {
   mode: string;
@@ -719,7 +719,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
         // Note: enabling this requires building the wasm engine using
         // ./scripts/build-wasm.sh (Emscripten SDK must be installed).
         try {
-          const nativeGlueUrl = `${import.meta.env.BASE_URL}worklets/openmpt-native.js`;
+          const nativeGlueUrl = getNativeGlueUrl();
           console.log('[INIT] Probing for native engine at:', nativeGlueUrl);
           const probeResp = await fetch(nativeGlueUrl, { method: 'HEAD' });
           if (probeResp.ok) {

--- a/hooks/useWorkletLoader.ts
+++ b/hooks/useWorkletLoader.ts
@@ -52,6 +52,17 @@ export const getWorkletUrl = (): string => {
 /**
  * Get absolute URL for the worklet (useful for cross-origin scenarios)
  */
+
+/**
+ * Returns the full URL for the native C++ AudioWorklet glue (openmpt-native.js)
+ * Uses the same robust BASE_URL logic as getWorkletUrl().
+ */
+export const getNativeGlueUrl = (): string => {
+  const base = import.meta.env.BASE_URL || '/';
+  const normalized = base.endsWith('/') ? base : `${base}/`;
+  return `${normalized}worklets/openmpt-native.js`;
+};
+
 export const getAbsoluteWorkletUrl = (): string => {
   const relativeUrl = getWorkletUrl();
   return new URL(relativeUrl, window.location.href).toString();
@@ -254,6 +265,7 @@ export function useWorkletLoader(options: UseWorkletLoaderOptions = {}) {
     verifyWorkletFile,
     getDiagnostics,
     getWorkletUrl,
+    getNativeGlueUrl,
     getAbsoluteWorkletUrl,
     isAudioWorkletSupported,
     lastError,

--- a/mod-player-shaders/useLibOpenMPT.ts
+++ b/mod-player-shaders/useLibOpenMPT.ts
@@ -7,6 +7,7 @@ import { ModuleMetadata, PatternMatrix } from '../types';
 import { OpenMPTWorkletEngine } from '../audio-worklet/OpenMPTWorkletEngine';
 import { getPatternMatrix } from './utils/patternExtractor';
 import { processModuleData as processModuleDataFn, startAudioPlayback } from './hooks/useAudioGraph';
+import { getWorkletUrl, getNativeGlueUrl } from '../hooks/useWorkletLoader';
 
 interface SyncDebugInfo {
   mode: string;
@@ -18,18 +19,8 @@ interface SyncDebugInfo {
 
 const DEFAULT_MODULE_URL = './4-mat_madness.mod';
 
-const detectRuntimeBase = (): string => {
-  const viteBase = import.meta.env.BASE_URL;
-  if (viteBase && viteBase !== '/') {
-    return viteBase.endsWith('/') ? viteBase : `${viteBase}/`;
-  }
-  const pathSegments = window.location.pathname.split('/').filter(Boolean);
-  if (pathSegments.length > 0) return `/${pathSegments[0]}/`;
-  return '/';
-};
-
-const RUNTIME_BASE_URL = detectRuntimeBase();
-const WORKLET_URL = `${RUNTIME_BASE_URL}worklets/openmpt-worklet.js`;
+// AUDIO-001 FIX COMPLETE: Use centralized worklet URL construction from useWorkletLoader
+const WORKLET_URL = getWorkletUrl();
 console.log('[AudioWorklet] Worklet URL resolved:', WORKLET_URL);
 
 const MAX_DRIFT_SECONDS = 0.1;
@@ -506,7 +497,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
         }
 
         try {
-          const nativeGlueUrl = `${RUNTIME_BASE_URL}worklets/openmpt-native.js`;
+          const nativeGlueUrl = getNativeGlueUrl();
           const probeResp = await fetch(nativeGlueUrl, { method: 'HEAD' });
           if (probeResp.ok) {
             const engine = new OpenMPTWorkletEngine();


### PR DESCRIPTION
I've added the `getNativeGlueUrl` function to `hooks/useWorkletLoader.ts` to implement centralized URL construction for `openmpt-native.js` following the same logic as `getWorkletUrl`. I updated `hooks/useLibOpenMPT.ts` and `mod-player-shaders/useLibOpenMPT.ts` to both use `getNativeGlueUrl` instead of manually constructing the URL. Additionally, `mod-player-shaders/useLibOpenMPT.ts` now properly imports and uses `getWorkletUrl` instead of manually constructing it, completing the remaining part of the AUDIO-001 ticket.

---
*PR created automatically by Jules for task [14910741375590085247](https://jules.google.com/task/14910741375590085247) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized worklet URL construction for improved code organization and maintainability. No changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/mod-player/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->