### PR TITLE
fix(ui): register v0.51 (Playhead Arc) in shader selector

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -40,6 +40,7 @@ const SHADER_GROUPS = {
   ],
   CIRCULAR: [
     { id: 'patternv0.50.wgsl', label: 'v0.50 (Trap Frosted Lens)' },
+    { id: 'patternv0.51.wgsl', label: 'v0.51 (Playhead Arc)' },
     { id: 'patternv0.49.wgsl', label: 'v0.49 (Trap Frosted Glass)' },
     { id: 'patternv0.48.wgsl', label: 'v0.48 (Trap Frosted Disc)' },
     { id: 'patternv0.47.wgsl', label: 'v0.47 (Trap Frosted)' },


### PR DESCRIPTION
Register the v0.51 "Playhead Arc" shader that exists in shaders/ and public/shaders/ but was missing from the App.tsx SHADER_OPTIONS selector. Verified no v0.52-v0.54 entries present and no stale editor artifacts (.bak, .kate-swp) in shader directories.

https://claude.ai/code/session_0198stmiLZxDZM3dfB4f4bvu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added v0.51 (Playhead Arc) shader option to the Circular shader selector, expanding available visual effects for users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/mod-player/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->