### PR TITLE
Fix TS1128/TS1005 syntax errors in useLibOpenMPT updateUI callback

### DIFF
--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -406,27 +406,9 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     setPlaybackRowFraction(smoothedPlayhead);
 
     // Compute note ages for hardware choke in shader (only update React state when integer ages change)
-    const playheadRow = row + smoothedRowFraction;
-    const currentMatrix = patternMatricesRef.current[order];
-    const numChannels = channelStatesRef.current.length;
-    if (currentMatrix && numChannels > 0) {
-    // TIMING FIX: Smooth row fraction for visual display
-    const targetPlayhead = row + rowFraction;
-    const prevPlayhead = playbackStateRef.current.playheadRow;
-    let smoothedPlayhead = prevPlayhead + (targetPlayhead - prevPlayhead) * ROW_INTERPOLATION_SMOOTHING;
-
-    // Snap if jump is too large (seek or pattern change)
-    if (Math.abs(targetPlayhead - prevPlayhead) > 2.0) {
-      smoothedPlayhead = targetPlayhead;
-    }
-
-    setPlaybackRowFraction(smoothedPlayhead);
-
-    // Compute note ages for hardware choke / shaders
     const playheadRow = smoothedPlayhead;
     const currentMatrix = patternMatricesRef.current[order];
     const numChannels = channelStatesRef.current.length;
-
     if (currentMatrix && numChannels > 0) {
       // PERFORMANCE: Only recompute on row boundary crossings
       const prev = playbackStateRef.current;
@@ -446,7 +428,6 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
             changed = true;
           }
 
-          // Update ref (mutable for shaders)
           channelStatesRef.current[c] = {
             ...existing,
             noteAge: newAge,
@@ -474,21 +455,17 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     const beatPhaseValue = (time * 2) % 1;
     setBeatPhase(beatPhaseValue);
 
-// TIMING FIX COMPLETE: Atomic update of playbackStateRef with worklet-provided timestamp
-const now = workletTimestampRef.current || (audioCtx?.currentTime || performance.now() / 1000);
+    const now = workletTimestampRef.current || (audioCtx?.currentTime || performance.now() / 1000);
 
-// Use the already-computed smoothed value for consistency
-const smoothedPlayhead = row + smoothedRowFraction;
-
-playbackStateRef.current = {
-  playheadRow: smoothedPlayhead,
-  currentOrder: order,
-  timeSec: time,
-  beatPhase: beatPhaseValue,
-  kickTrigger: kickTrigger,
-  grooveAmount: grooveAmount,
-  lastUpdateTimestamp: now
-};
+    playbackStateRef.current = {
+      playheadRow: smoothedPlayhead,
+      currentOrder: order,
+      timeSec: time,
+      beatPhase: beatPhaseValue,
+      kickTrigger: kickTrigger,
+      grooveAmount: grooveAmount,
+      lastUpdateTimestamp: now
+    };
 
     // TIMING FIX: Update sync debug info
     setSyncDebug((prev: SyncDebugInfo) => ({


### PR DESCRIPTION
## Summary

- Removed a duplicate injected block inside `updateUI`'s `if (currentMatrix && numChannels > 0)` branch that caused an unclosed brace and redeclared variables (`playheadRow`, `currentMatrix`, `numChannels`, `smoothedPlayhead`)
- Fixed the undefined `smoothedRowFraction` reference (replaced with the already-computed `smoothedPlayhead`)
- The two reported errors (`TS1128: Declaration or statement expected` and `TS1005: ';' expected` at line 513) are now resolved

## Test plan

- [ ] `npm run typecheck` no longer reports errors in `hooks/useLibOpenMPT.ts`
- [ ] `npm run build` completes successfully
- [ ] Audio playback and pattern visualization behave correctly in browser

https://claude.ai/code/session_01Tz6gvESAksPEXTP4FJBPGP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tz6gvESAksPEXTP4FJBPGP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of playhead timing and computation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/mod-player/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->