### PR TITLE
Remove stale local SyncDebugInfo interface that shadowed the imported…

### DIFF
--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -6,13 +6,6 @@ import { startAudioPlayback, AudioGraphRefs, AudioGraphCallbacks, AudioGraphConf
 import { useWorkletLoader, getWorkletUrl, getNativeGlueUrl, getAbsoluteWorkletUrl } from './useWorkletLoader';
 import { logWorkletDiagnostics } from '../audio-worklet/diagnostics';
 
-interface SyncDebugInfo {
-  mode: string;
-  bufferMs: number;
-  driftMs: number;
-  row: number;
-  starvationCount: number;
-}
 
 // Use Vite BASE_URL for correct resolution under subdirectory deployment
 const DEFAULT_MODULE_URL = `${import.meta.env.BASE_URL}4-mat_madness.mod`;


### PR DESCRIPTION
… type

The local interface at the top of useLibOpenMPT.ts only declared 5 fields, shadowing the full 14-field version imported from types.ts. This caused TS2440 (import conflict) and TS2339 errors for all the extended diagnostic fields used in App.tsx and the setSyncDebug call.

https://claude.ai/code/session_01Tz6gvESAksPEXTP4FJBPGP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated diagnostic type definitions by importing shared type definition instead of maintaining duplicate local declaration, ensuring consistency across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/mod-player/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->