### PR TITLE
Fix infinite render loop (React error #185) in useLocalStorage

### DIFF
--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -3,21 +3,49 @@ import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 type Setter<T> = T | ((previousValue: T) => T);
 
 export function useLocalStorage<T>(key: string, defaultValue: T): [T, (value: Setter<T>) => void] {
+  // Stabilize defaultValue across renders. Callers commonly pass an inline literal
+  // (e.g. `{}` or `[]`), which would otherwise be a fresh reference every render and
+  // break useSyncExternalStore's referential-equality contract.
+  const defaultValueRef = useRef<T>(defaultValue);
+
   const subscribe = useCallback((callback: () => void) => {
     window.addEventListener('storage', callback);
     return () => window.removeEventListener('storage', callback);
   }, []);
 
-  const getSnapshot = useCallback(() => {
-    try {
-      const raw = window.localStorage.getItem(key);
-      return raw !== null ? (JSON.parse(raw) as T) : defaultValue;
-    } catch {
-      return defaultValue;
-    }
-  }, [defaultValue, key]);
+  // Cache the parsed snapshot keyed by the raw string from localStorage so repeated
+  // getSnapshot() calls return the SAME reference until the stored value actually changes.
+  const cachedRawRef = useRef<string | null | undefined>(undefined);
+  const cachedValueRef = useRef<T>(defaultValue);
 
-  const value = useSyncExternalStore(subscribe, getSnapshot, () => defaultValue);
+  const getSnapshot = useCallback((): T => {
+    let raw: string | null;
+    try {
+      raw = window.localStorage.getItem(key);
+    } catch {
+      return defaultValueRef.current;
+    }
+    if (raw === null) {
+      if (cachedRawRef.current !== null) {
+        cachedRawRef.current = null;
+        cachedValueRef.current = defaultValueRef.current;
+      }
+      return cachedValueRef.current;
+    }
+    if (raw !== cachedRawRef.current) {
+      try {
+        cachedValueRef.current = JSON.parse(raw) as T;
+      } catch {
+        cachedValueRef.current = defaultValueRef.current;
+      }
+      cachedRawRef.current = raw;
+    }
+    return cachedValueRef.current;
+  }, [key]);
+
+  const getServerSnapshot = useCallback((): T => defaultValueRef.current, []);
+
+  const value = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const valueRef = useRef<T>(value);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

The app was crashing at startup with React minified error #185 ("Maximum update depth exceeded"). Root cause: `hooks/useLocalStorage.ts` violates the `useSyncExternalStore` contract.

- `getSnapshot` called `JSON.parse(raw)` on every invocation, producing a new object each time even when nothing changed. React called it during render, saw a different value, scheduled another render, and looped.
- The `defaultValue` argument was typically passed as an inline `{}` / `[]` literal (e.g. `useLocalStorage('xasm1-shader-thumbnails', {})`), so its reference changed every render — destabilizing both `getServerSnapshot` and the `getSnapshot` `useCallback` identity.

## Fix

- Cache the parsed snapshot keyed by the raw localStorage string, so repeated `getSnapshot()` calls return the same reference until the stored value actually changes.
- Stash `defaultValue` in a ref so the snapshot callbacks stay referentially stable across renders.

## Test plan

- [ ] App loads without React error #185 in production build
- [ ] Shader thumbnails, favorites, recents, theme, debug-panel-open, chassis-dark all still persist across reloads
- [ ] Storage event from another tab still triggers re-render


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hv3UfyHNzvLkaD75htNCQT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local storage hook performance by stabilizing default value references across renders.
  * Optimized snapshot caching to reduce unnecessary re-renders and ensure consistent value references.
  * Enhanced error handling for parsing and read failures with more consistent fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/mod-player/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->