### PR TITLE
fix: strip ES module export statements before new Function() eval in worklet

### DIFF
--- a/public/worklets/openmpt-worklet.js
+++ b/public/worklets/openmpt-worklet.js
@@ -137,10 +137,14 @@ class XMPlayerProcessor extends AudioWorkletProcessor {
         noInitialRun: true,
       };
 
+      // Strip ES module export statements — new Function() is a classic-script
+      // context and will throw SyntaxError on any top-level `export` keyword.
+      const cleanedScript = scriptText.replace(/^\s*export\s+(default\s+)?/gm, '');
+
       // Evaluate the Emscripten-generated script in the global scope.
       // new Function() runs with globalThis as its outer scope, so the script
       // sees (and modifies) globalThis.libopenmpt via normal variable lookup.
-      const fn = new Function(scriptText); // eslint-disable-line no-new-func
+      const fn = new Function(cleanedScript); // eslint-disable-line no-new-func
       fn.call(globalThis);
 
       let lib = globalThis.libopenmpt;


### PR DESCRIPTION
## Summary

- `libopenmpt-audioworklet.js` ends with `export default Module;`, an ES module statement
- `new Function(scriptText)` creates a classic-script function body context, which throws `SyntaxError: Unexpected token 'export'` when it encounters the export keyword
- Fix: strip top-level `export` keywords from `scriptText` before passing to `new Function()` in `_handleInitLib`

## Test plan

- [ ] Load a `.mod`/`.xm`/`.s3m` file and confirm audio plays without the `SyntaxError: Unexpected token 'export'` console error
- [ ] Verify the WASM library initialises successfully (look for `[Worklet] libopenmpt ready ✅` in console)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVKG8xhX8C3uNGyUVtegSD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script loading compatibility issue in OpenMPT worklet.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/mod-player/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->