### PR TITLE
fix: polyfill performance.now() for Emscripten in AudioWorklet scope

### DIFF
--- a/public/worklets/openmpt-worklet.js
+++ b/public/worklets/openmpt-worklet.js
@@ -130,6 +130,13 @@ class XMPlayerProcessor extends AudioWorkletProcessor {
 
       log('Evaluating libopenmpt-audioworklet.js (', scriptText.length, ' chars)…');
 
+      // Emscripten calls performance.now() internally (_emscripten_get_now).
+      // AudioWorkletGlobalScope may not expose `performance` as a global, so
+      // polyfill it using currentTime (the high-resolution audio clock).
+      if (typeof globalThis.performance === 'undefined') {
+        globalThis.performance = { now: () => currentTime * 1000 };
+      }
+
       // Pre-configure the Emscripten Module object. Emscripten checks
       // "typeof libopenmpt !== 'undefined'" and merges with this object.
       globalThis.libopenmpt = {


### PR DESCRIPTION
Emscripten's _emscripten_get_now() calls performance.now() as a free variable. AudioWorkletGlobalScope does not guarantee `performance` is exposed on globalThis, causing ReferenceError when the WASM module is evaluated via new Function(). Polyfill it with currentTime * 1000 (the high-resolution audio clock) before the eval.