### PR TITLE
feat: register patternv0.55.wgsl (Oscilloscope) in shader selector

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -47,6 +47,7 @@ const SHADER_GROUPS = {
   CIRCULAR: [
     { id: 'patternv0.50.wgsl', label: 'v0.50 (Trap Frosted Lens)' },
     { id: 'patternv0.51.wgsl', label: 'v0.51 (Playhead Arc)' },
+    { id: 'patternv0.55.wgsl', label: 'v0.55 (Oscilloscope)' },
     { id: 'patternv0.49.wgsl', label: 'v0.49 (Trap Frosted Glass)' },
     { id: 'patternv0.48.wgsl', label: 'v0.48 (Trap Frosted Disc)' },
     { id: 'patternv0.47.wgsl', label: 'v0.47 (Trap Frosted)' },

--- a/public/shaders/patternv0.55.wgsl
+++ b/public/shaders/patternv0.55.wgsl
@@ -598,7 +598,7 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
 
     if (isNoteOn || isSustain) {
       let pitchHue = pitchClassFromIndex(note);
-      let baseColor = neonPalette(pitchHue);
+      let baseColor = selectPalette(uniforms.colorPalette, pitchHue);
       let instBand = inst & 15u;
       let instBright = 0.85 + (select(0.0, f32(instBand) / 15.0, instBand > 0u)) * 0.15;
       noteColor = baseColor * instBright;


### PR DESCRIPTION
Also sync public/shaders/patternv0.55.wgsl to canonical shaders/ copy: neonPalette() hardcoded call replaced with selectPalette(uniforms.colorPalette) so the color-palette selector respects user choice in v0.55.

https://claude.ai/code/session_01GALhrsKUJjsVyR6NAxRCCx