### PR TITLE
fix: add .env.production to bake correct /xm-player/ base path into builds

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_APP_BASE_PATH=/xm-player/


### PR DESCRIPTION
## Summary

- Adds `.env.production` with `VITE_APP_BASE_PATH=/xm-player/`
- Vite automatically loads this file during `npm run build`, so `import.meta.env.BASE_URL` is correctly baked in as `/xm-player/` without needing to manually prefix the env var every time
- Without this, `BASE_URL` defaults to `/`, causing all asset fetches (shaders, worklets, `.mod` files) to 404 on the subdirectory deployment at `test.1ink.us/xm-player/`

## Root cause

The build was run as plain `npm run build` instead of `VITE_APP_BASE_PATH=/xm-player/ npm run build`. The `deploy.py` script documents the correct command but it was easy to miss. This commit makes the correct base path automatic for all production builds.

## Test plan

- [ ] Run `npm run build` (no env prefix needed now)
- [ ] Check that bundled JS references `/xm-player/` asset paths
- [ ] Deploy and confirm shaders, worklets, and default `.mod` load without 404s

https://claude.ai/code/session_0139136nD9YdA7A578NW1ZsC

---
_Generated by [Claude Code](https://claude.ai/code/session_0139136nD9YdA7A578NW1ZsC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment configuration to specify the correct base path for application deployment and resource access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->