### PR TITLE
Fix subpath asset URL resolution

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1042,7 +1042,9 @@ function App() {
               syncPending={syncLibraryMutation.isPending}
               syncError={syncLibraryErrorMessage}
               activeModule={activeModuleForSave}
-              onSaveModule={(req) => saveSongMutation.mutateAsync(req)}
+              onSaveModule={async (req) => {
+                await saveSongMutation.mutateAsync(req);
+              }}
               savePending={saveSongMutation.isPending}
               saveError={saveSongErrorMessage}
             />

--- a/audio-worklet/OpenMPTWorkletEngine.ts
+++ b/audio-worklet/OpenMPTWorkletEngine.ts
@@ -25,6 +25,7 @@ import type {
     EmscriptenOpenMPTModule,
     CreateOpenMPTModule,
 } from './types';
+import { withBase } from '../src/lib/paths';
 
 // ── Public constants ─────────────────────────────────────────────────
 
@@ -137,8 +138,7 @@ export class OpenMPTWorkletEngine extends MiniEventEmitter<EngineEventMap> {
      */
     constructor(options?: NativeEngineOptions) {
         super();
-        // Default to Vite's BASE_URL + worklets/
-        this.basePath = options?.basePath ?? `${import.meta.env.BASE_URL}worklets/`;
+        this.basePath = options?.basePath ?? withBase('worklets/');
         this.sharedOutputBuffer = options?.sharedOutputBuffer ?? null;
     }
 
@@ -174,7 +174,7 @@ export class OpenMPTWorkletEngine extends MiniEventEmitter<EngineEventMap> {
             let glueModule: Record<string, unknown>;
             // The JS worklet processor (openmpt-worklet.js) references AudioWorkletProcessor
             // and cannot be imported on the main thread. Only try the native Emscripten glue.
-            const nativeUrl = `${import.meta.env.BASE_URL}worklets/openmpt-native.js`;
+            const nativeUrl = withBase('worklets/openmpt-native.js');
             glueModule = await import(/* @vite-ignore */ nativeUrl) as Record<string, unknown>;
             const createModule = (glueModule.default || glueModule['createOpenMPTModule']) as CreateOpenMPTModule;
 

--- a/components/PatternDisplay.tsx
+++ b/components/PatternDisplay.tsx
@@ -6,6 +6,7 @@ import { useWebGPURender, type WebGPURenderParams, type DebugInfo } from '../hoo
 import { BloomPostProcessor } from '../utils/bloomPostProcessor';
 import { WEBGL_HYBRID_SHADERS, supportsStepsLength } from '../utils/shaderVersion';
 import { getShaderMeta } from '../utils/shaderRegistry';
+import { detectRuntimeBase } from '../src/lib/paths';
 import { getBloomProfile } from '../utils/bloomProfiles';
 
 const DEFAULT_CHANNELS = 4;
@@ -371,7 +372,7 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
       ? { layers: [...bloomLayers], finalFormat: navigator.gpu.getPreferredCanvasFormat() }
       : { finalFormat: navigator.gpu.getPreferredCanvasFormat() };
     const bloom = new BloomPostProcessor(device, canvas, context, bloomOptions);
-    bloom.setBaseUrl(import.meta.env.BASE_URL);
+    bloom.setBaseUrl(detectRuntimeBase());
     bloom.init().then(() => {
       bloomRef.current = bloom;
     }).catch((err: unknown) => {

--- a/components/ShaderSelectorPanel.tsx
+++ b/components/ShaderSelectorPanel.tsx
@@ -1,5 +1,6 @@
 import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '../utils/cn';
+import { withBase } from '../src/lib/paths';
 import type { ShaderMeta } from '../utils/storageApi';
 
 interface ShaderOption {
@@ -139,7 +140,7 @@ export function ShaderSelectorPanel({
     const isSelected = selectedShader === option.id;
     const isActive = activeIndex === index;
     const liveThumbnail = thumbnails[option.id];
-    const staticThumbnail = `${import.meta.env.BASE_URL}shaders/thumbnails/${option.id}.wgsl.png`;
+    const staticThumbnail = withBase(`shaders/thumbnails/${option.id}.wgsl.png`);
     const thumbnailSrc = liveThumbnail ?? staticThumbnail;
     const cloudMeta = catalogById.get(option.id);
 

--- a/hooks/useAudioGraph.ts
+++ b/hooks/useAudioGraph.ts
@@ -9,6 +9,7 @@ import { getWorkletUrl } from './useWorkletLoader';
 import { computeNoteAges } from '../utils/patternExtractor';
 import { broadcastPcmBlock } from '../utils/projectMBridge';
 import { logWorkletDiagnostics } from '../audio-worklet/diagnostics';
+import { detectRuntimeBase, withBase } from '../src/lib/paths';
 
 export interface AudioGraphRefs {
   libopenmptRef:       React.MutableRefObject<LibOpenMPT | null>;
@@ -197,7 +198,7 @@ export async function startAudioPlayback(
         const ringByteOffset = engine.getRingBufByteOffset();
         if (wasmSAB && ringByteOffset > 0) {
           try {
-            const bridgeUrl = `${import.meta.env.BASE_URL}worklets/native-bridge-processor.js`;
+            const bridgeUrl = withBase('worklets/native-bridge-processor.js');
             await ctx.audioWorklet.addModule(bridgeUrl);
             const bridgeNode = new AudioWorkletNode(ctx, 'native-bridge-processor', {
               numberOfInputs: 0,
@@ -429,7 +430,7 @@ export async function startAudioPlayback(
         }
         if (wasmMemory) processorOptions.memory = wasmMemory;
         // Pass base URL so the worklet can resolve WASM/co-located assets correctly
-        processorOptions.baseUrl = import.meta.env.BASE_URL || '/';
+        processorOptions.baseUrl = detectRuntimeBase();
         
         // AUDIO-001 FIX COMPLETE: Wrap node creation in try-catch for better diagnostics
         let node: AudioWorkletNode;
@@ -452,7 +453,7 @@ export async function startAudioPlayback(
         // AudioWorklet classic scripts cannot use import() or importScripts(), so we
         // do the fetch here where fetch() is always available.
         console.log('[PLAY] Fetching libopenmpt assets for worklet...');
-        const workletBaseUrl = (import.meta.env.BASE_URL || '/') + 'worklets/';
+        const workletBaseUrl = withBase('worklets/');
         let libJsText: string;
         let libWasmBuffer: ArrayBuffer;
         try {

--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -5,10 +5,11 @@ import { computeNoteAges } from '../utils/patternExtractor';
 import { startAudioPlayback, AudioGraphRefs, AudioGraphCallbacks, AudioGraphConfig } from './useAudioGraph';
 import { useWorkletLoader, getWorkletUrl, getNativeGlueUrl, getAbsoluteWorkletUrl } from './useWorkletLoader';
 import { logWorkletDiagnostics } from '../audio-worklet/diagnostics';
+import { withBase } from '../src/lib/paths';
 
 
 // Use Vite BASE_URL for correct resolution under subdirectory deployment
-const DEFAULT_MODULE_URL = `${import.meta.env.BASE_URL}4-mat_madness.mod`;
+const DEFAULT_MODULE_URL = withBase('4-mat_madness.mod');
 
 // AUDIO-001 FIX COMPLETE: Use centralized worklet URL construction from useWorkletLoader
 const WORKLET_URL = getWorkletUrl();

--- a/hooks/useWebGPURender.ts
+++ b/hooks/useWebGPURender.ts
@@ -36,7 +36,7 @@ import {
 } from '../utils/computeNoteDuration';
 import type { BloomPostProcessor } from '../utils/bloomPostProcessor';
 import { GRID_RECT } from '../utils/geometryConstants';
-import { detectRuntimeBase } from '../src/lib/paths';
+import { detectRuntimeBase, withBase } from '../src/lib/paths';
 
 export type DebugInfo = {
   layoutMode: string;
@@ -276,8 +276,12 @@ export function useWebGPURender(
         textureResourcesRef.current = null;
         bezelTextureResourcesRef.current = null;
 
-        const shaderBase = import.meta.env.BASE_URL;
-        const shaderSource = await fetch(`${shaderBase}shaders/${shaderFile}`).then(r => r.text());
+        const shaderUrl = withBase(`shaders/${shaderFile}`);
+        const shaderResponse = await fetch(shaderUrl);
+        if (!shaderResponse.ok) {
+          throw new Error(`Could not load shader at ${shaderUrl} (${shaderResponse.status})`);
+        }
+        const shaderSource = await shaderResponse.text();
         if (cancelled) return;
         const module = device.createShaderModule({ code: shaderSource });
         if ('getCompilationInfo' in module) module.getCompilationInfo().catch(() => {});
@@ -317,7 +321,12 @@ export function useWebGPURender(
         if (shouldUseBackgroundPass(shaderFile)) {
           try {
             const backgroundShaderFile = getBackgroundShaderFile(shaderFile);
-            const backgroundSource = await fetch(`${shaderBase}shaders/${backgroundShaderFile}`).then(r => r.text());
+            const backgroundShaderUrl = withBase(`shaders/${backgroundShaderFile}`);
+            const backgroundResponse = await fetch(backgroundShaderUrl);
+            if (!backgroundResponse.ok) {
+              throw new Error(`Could not load background shader at ${backgroundShaderUrl} (${backgroundResponse.status})`);
+            }
+            const backgroundSource = await backgroundResponse.text();
             const bezelModule = device.createShaderModule({ code: backgroundSource });
             const bezelBindLayout = device.createBindGroupLayout({ entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } }, { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } }, { binding: 2, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } }] });
             bezelPipelineRef.current = device.createRenderPipeline({ layout: device.createPipelineLayout({ bindGroupLayouts: [bezelBindLayout] }), vertex: { module: bezelModule, entryPoint: 'vs' }, fragment: { module: bezelModule, entryPoint: 'fs', targets: [{ format }] }, primitive: { topology: 'triangle-list' } });

--- a/hooks/useWorkletLoader.ts
+++ b/hooks/useWorkletLoader.ts
@@ -9,6 +9,7 @@
  */
 
 import { useCallback, useRef, useState } from 'react';
+import { detectRuntimeBase } from '../src/lib/paths';
 
 export interface WorkletLoadResult {
   success: boolean;
@@ -42,11 +43,7 @@ export interface UseWorkletLoaderOptions {
  * browsers. A version query parameter forces a fresh load after deploys.
  */
 export const getWorkletUrl = (): string => {
-  // Try multiple strategies for URL construction, ordered by reliability
-
-  // Strategy 1: Use Vite's BASE_URL (most reliable for Vite builds)
-  const viteBase = import.meta.env.BASE_URL || '/';
-  const base = viteBase.endsWith('/') ? viteBase : `${viteBase}/`;
+  const base = detectRuntimeBase();
   // BUMP this version whenever openmpt-worklet.js changes to bust browser caches
   const WORKLET_VERSION = '2';
   const url = `${base}worklets/openmpt-worklet.js?v=${WORKLET_VERSION}`;
@@ -63,9 +60,7 @@ export const getWorkletUrl = (): string => {
  * Uses the same robust BASE_URL logic as getWorkletUrl().
  */
 export const getNativeGlueUrl = (): string => {
-  const base = import.meta.env.BASE_URL || '/';
-  const normalized = base.endsWith('/') ? base : `${base}/`;
-  return `${normalized}worklets/openmpt-native.js`;
+  return `${detectRuntimeBase()}worklets/openmpt-native.js`;
 };
 
 export const getAbsoluteWorkletUrl = (): string => {
@@ -133,7 +128,7 @@ export function useWorkletLoader(options: UseWorkletLoaderOptions = {}) {
       url: workletUrl,
       audioContextState: audioContext.state,
       sampleRate: audioContext.sampleRate,
-      baseUrl: import.meta.env.BASE_URL,
+      baseUrl: detectRuntimeBase(),
       timestamp: new Date().toISOString(),
       loadAttempts: 0,
     };
@@ -259,7 +254,7 @@ export function useWorkletLoader(options: UseWorkletLoaderOptions = {}) {
       url: getWorkletUrl(),
       audioContextState: 'unknown',
       sampleRate: 0,
-      baseUrl: import.meta.env.BASE_URL,
+      baseUrl: detectRuntimeBase(),
       timestamp: new Date().toISOString(),
       loadAttempts: loadAttemptsRef.current,
     };

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -14,11 +14,12 @@ export const detectRuntimeBase = (): string => {
   if (viteBase && viteBase !== '/') {
     return viteBase.endsWith('/') ? viteBase : `${viteBase}/`;
   }
-  const pathSegments = window.location.pathname.split('/').filter(Boolean);
-  if (pathSegments.length > 0) {
-    return `/${pathSegments[0]}/`;
+  const pathname = window.location.pathname || '/';
+  if (pathname.endsWith('/')) {
+    return pathname;
   }
-  return '/';
+  const lastSlash = pathname.lastIndexOf('/');
+  return lastSlash >= 0 ? pathname.slice(0, lastSlash + 1) : '/';
 };
 
 /**
@@ -27,12 +28,10 @@ export const detectRuntimeBase = (): string => {
  * @returns The full URL with base path
  */
 export const withBase = (p: string): string => {
-  const base = import.meta.env.BASE_URL || '/'
-  // Remove leading slash from path to avoid double slashes
-  const cleanPath = p.replace(/^\//, '')
-  // Combine base (which always ends with /) with clean path
-  return base + cleanPath
-}
+  const base = detectRuntimeBase();
+  const cleanPath = p.replace(/^\//, '');
+  return `${base}${cleanPath}`;
+};
 
 /**
  * Creates an absolute URL from a path, handling base URL correctly.
@@ -40,7 +39,7 @@ export const withBase = (p: string): string => {
  * @returns Full absolute URL string
  */
 export const withBaseAbsolute = (p: string): string => {
-  const base = import.meta.env.BASE_URL || '/'
-  const cleanPath = p.replace(/^\//, '')
-  return new URL(cleanPath, window.location.origin + base).toString()
-}
+  const base = detectRuntimeBase();
+  const cleanPath = p.replace(/^\//, '');
+  return new URL(cleanPath, `${window.location.origin}${base}`).toString();
+};

--- a/utils/computeNoteDuration.ts
+++ b/utils/computeNoteDuration.ts
@@ -2,6 +2,7 @@
 // Replaces the CPU O(rows×channels) scan with a WebGPU compute pass.
 
 import type { PatternMatrix } from '../types';
+import { withBase } from '../src/lib/paths';
 
 const MAX_SHADER_ROWS = 1024; // Must match MAX_ROWS in compute_note_duration.wgsl
 
@@ -23,8 +24,12 @@ export async function initNoteDurationCompute(device: GPUDevice): Promise<NoteDu
     return cachedState;
   }
 
-  const shaderBase = import.meta.env.BASE_URL;
-  const shaderCode = await fetch(`${shaderBase}shaders/compute_note_duration.wgsl`).then((r) => r.text());
+  const shaderUrl = withBase('shaders/compute_note_duration.wgsl');
+  const shaderResponse = await fetch(shaderUrl);
+  if (!shaderResponse.ok) {
+    throw new Error(`Could not load shader at ${shaderUrl} (${shaderResponse.status})`);
+  }
+  const shaderCode = await shaderResponse.text();
 
   const module = device.createShaderModule({ code: shaderCode });
   if ('getCompilationInfo' in module) {

--- a/utils/remoteMedia.ts
+++ b/utils/remoteMedia.ts
@@ -1,7 +1,8 @@
 import type { MediaItem } from '../types';
+import { withBase } from '../src/lib/paths';
 
 // Adjust this path to match where you drop your files on the FTP
-const REMOTE_MEDIA_BASE_URL = `${import.meta.env.BASE_URL}media/`;
+const REMOTE_MEDIA_BASE_URL = withBase('media/');
 const moduleFetchCache = new Map<string, Promise<Uint8Array>>();
 const MAX_MODULE_CACHE_ENTRIES = 64;
 

--- a/utils/storageApi.ts
+++ b/utils/storageApi.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { withBase } from '../src/lib/paths';
 
 const storageBaseUrl = (import.meta.env.VITE_STORAGE_API_URL ?? '').trim().replace(/\/+$/, '');
 
@@ -70,7 +71,7 @@ export interface ShaderMeta {
 }
 
 function toApiUrl(path: string): string {
-  if (!storageBaseUrl) return path;
+  if (!storageBaseUrl) return withBase(path);
   return `${storageBaseUrl}${path}`;
 }
 


### PR DESCRIPTION
### Motivation
- Deployments under a subpath (e.g. `/xm-player/`) produced 404s for worklets, shaders, media and API fallbacks because many runtime asset URLs were built as root-relative paths. 404 HTML was being fed into WGSL compilation and AudioWorklet loading, causing runtime failures. 

### Description
- Add runtime base-path detection and helpers: `detectRuntimeBase()` and `withBase()` in `src/lib/paths.ts` and switch URL construction to use those helpers instead of relying directly on `import.meta.env.BASE_URL` when that value is `/`.
- Use the new helpers across the codebase to resolve assets correctly under subpaths, including: worklet loading and diagnostics (`hooks/useWorkletLoader.ts`), JS/C++ worklet glue and native engine paths (`audio-worklet/OpenMPTWorkletEngine.ts`, `hooks/useAudioGraph.ts`, `hooks/useLibOpenMPT.ts`), shader loading and background shader loading (`hooks/useWebGPURender.ts`), compute shader (`utils/computeNoteDuration.ts`), bloom post-processor (`components/PatternDisplay.tsx`), thumbnails (`components/ShaderSelectorPanel.tsx`), remote media listing (`utils/remoteMedia.ts`), and storage API fallback handling (`utils/storageApi.ts`).
- Harden shader and compute shader fetches with explicit HTTP status checks and meaningful errors so WGSL/compute shader compilation does not receive HTML error pages.
- Propagate the detected runtime base into worklet `processorOptions.baseUrl` and native engine initialization so the worklet can resolve its companion assets correctly.
- Minor TypeScript/API fix: adapt the `onSaveModule` callback to return a `Promise<void>` (`App.tsx`) to satisfy strict typing while preserving behavior.

### Testing
- Ran type checking with `npm run typecheck` (passed).
- Ran linter with `npm run lint` (project linter is currently a no-op; command exited 0).
- Verified production builds with `npm run build` and with `VITE_APP_BASE_PATH=/xm-player/ npm run build` (both completed successfully; Vite emitted an unrelated CSS minification warning about `inst` ≈ `inset`).
- Attempted the packing invariant smoke test (`node utils/__debug__/packingInvariants.test.cjs`), but the test invocation uses `npx tsx` and was blocked in this environment by a `403 Forbidden` from the npm registry, so that debug script could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a235ce36b38832fbdd48ece6c79d655)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset and shader loading for deployments with custom base paths or subdirectories.
  * Improved error handling and reporting when assets fail to load.
  * Enhanced URL resolution for various hosting configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->