### PR TITLE
TRIG-001: Trigger nodes with sustain tails (dual-state LED system)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - **Bundler / Dev Server:** Vite 5
 - **Styling:** Tailwind CSS 3.3 + PostCSS + Autoprefixer, with custom scrollbars and a five-theme CSS variable system in `index.css`
 - **3D Graphics:** `@react-three/fiber` + `@react-three/drei` + `three`
-- **Visualization:** WebGPU (WGSL shaders), *not* WebGL
+- **Visualization:** WebGPU (WGSL shaders) primary; **WebGL2** GLSL reference renderer (`src/renderers/webgl2/`) and **HTML** fallback
 - **Audio Backend:** `libopenmpt` (WASM) inside a customized AudioWorklet
 - **Native Audio Engine:** C++17 → Emscripten (`build-wasm.sh` or `scripts/build-wasm.sh`)
 - **Module System:** ES modules (`"type": "module"` in `package.json`)
@@ -60,7 +60,8 @@ If the JS AudioWorklet fails to initialize WASM, `hooks/useAudioGraph.ts` falls 
   - **Video:** v0.23 (Clouds), v0.24 (Tunnel)
 - **Pipeline:** Shaders are fetched as raw text strings (often via `fetch()` or bundled strings) and passed into the WebGPU render pipeline in components like `PatternDisplay.tsx` and `Studio3D.tsx`.
 - **Bloom:** Post-processing bloom passes live in `utils/bloomPostProcessor.ts`; presets are defined in `types/bloomPresets.ts`.
-- **Compatibility:** WebGPU support is required for the shader visualizer. If unavailable, the app falls back to an HTML pattern renderer (`components/PatternSequencer.tsx`).
+- **Compatibility:** Three-tier renderer chain: WebGPU → WebGL2 → HTML. Select with `?renderer=webgpu|webgl2|html`, debug panel, or `window.DEBUG_RENDERER`. HTML fallback: `src/renderers/html/PatternHTMLFallback.tsx` (wraps `PatternSequencer.tsx`).
+- **Agent/CI:** `window.currentPatternRenderer` exposes `readPixels()`, `setDebugMode()`, `getCanvas()` on WebGL2/HTML backends.
 - **Critical Coupling:** Shaders are not pure assets. `PatternDisplay.tsx` parses the shader **filename** (e.g., `patternv0.37.wgsl`) to determine layout type, buffer packing strategy, canvas size, and whether shader-embedded UI controls exist. Changing a shader's uniform struct requires a matching update to `createUniformPayload()` in TypeScript.
 
 ## Data Packing for GPU
@@ -74,6 +75,7 @@ Tracker cells are bit-packed into `Uint32Array` before upload to the GPU:
 
 ## Directory Map
 - **`/components`** – React UI elements (`App.tsx`, `PatternDisplay.tsx`, `Controls.tsx`, `Studio3D.tsx`, `MediaOverlay.tsx`, `ChannelMeters.tsx`, `PatternSequencer.tsx`, `Playlist.tsx`, `SeekBar.tsx`, etc.)
+- **`/src/renderers`** – Pattern renderer selection + WebGL2 reference implementation + HTML fallback wrapper
 - **`/hooks`** – Core logic hooks
   - `useLibOpenMPT.ts` – Main audio bridge and state
   - `useAudioGraph.ts` – Audio graph construction and playback start

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - **React 18 + TypeScript + Vite** — UI framework and build tooling
 - **libopenmpt (WASM)** — Accurate tracker module audio playback, loaded from CDN
 - **Web Audio API + AudioWorklet** — Audio rendering pipeline (ScriptProcessorNode fallback)
-- **WebGPU + WGSL** — Hardware-accelerated visualization; falls back to an HTML grid view
+- **WebGPU + WGSL** — Hardware-accelerated visualization; **WebGL2** GLSL reference renderer and **HTML** grid as fallbacks
 - **Tailwind CSS** — Styling
 - **Three.js / React-Three-Fiber** — Optional 3D visualization mode
 
@@ -36,7 +36,7 @@ mod-player/
 ├── components/
 │   ├── PatternDisplay.tsx       # PRIMARY VISUALIZATION — WebGPU context, shaders, render loop
 │   ├── Controls.tsx             # File upload, play/stop, volume/pan sliders
-│   ├── PatternSequencer.tsx     # HTML fallback pattern grid (no WebGPU)
+│   ├── PatternSequencer.tsx     # HTML fallback pattern grid (wired via src/renderers/html/)
 │   ├── MediaOverlay.tsx         # Synchronized image/video overlay during playback
 │   ├── MediaPanel.tsx           # Media file management UI
 │   ├── ChannelMeters.tsx        # Real-time per-channel VU meters
@@ -57,6 +57,10 @@ mod-player/
 │   ├── bloomPostProcessor.ts    # WebGPU multi-pass bloom effect
 │   └── remoteMedia.ts           # Fetches/caches MOD files and media from remote servers
 │
+├── src/renderers/               # Pattern renderer abstraction (webgpu/webgl2/html selection)
+│   ├── rendererSelection.ts     # ?renderer= URL param, localStorage, DEBUG_RENDERER
+│   ├── webgl2/                  # GLSL 3.00 ES reference renderer + bloom
+│   └── html/                    # PatternHTMLFallback (wraps PatternSequencer)
 ├── shaders/                     # WGSL source shaders (~56 files, e.g. patternv0.45.wgsl)
 ├── shaders-enhanced/            # Experimental enhanced shader variants
 ├── public/
@@ -86,7 +90,17 @@ npm run build:emcc   # Alternative Emscripten build (scripts/build-wasm.sh)
 python3 deploy.py    # Build + SFTP upload to production server
 ```
 
-**Browser requirement:** WebGPU requires Chrome 113+, Edge 113+, or Arc. For headless testing pass `--enable-unsafe-webgpu`.
+**Browser requirement:** WebGPU requires Chrome 113+, Edge 113+, or Arc. For headless testing pass `--enable-unsafe-webgpu`. Use `?renderer=webgl2` when WebGPU is unavailable or for GLSL-based debugging.
+
+### Pattern Renderer Backends
+
+| Backend | Entry | Use case |
+|---------|-------|----------|
+| `webgpu` | default | Production visuals (WGSL + bloom) |
+| `webgl2` | `?renderer=webgl2` | Reference GLSL port, Playwright screenshots, `window.currentPatternRenderer.readPixels()` |
+| `html` | `?renderer=html` | Lightweight DOM grid, no GPU |
+
+Toggle via debug panel (🔍), `localStorage.xasm1_pattern_renderer`, or `window.DEBUG_RENDERER`. WebGL2 debug: **Alt+D** cycles wireframe/UV/playhead modes (dev only).
 
 **Deployment env var:** `VITE_APP_BASE_PATH=/xm-player/ npm run build` for subdirectory hosting.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Recent changes
 - v0.35: added "Donut & Night Mode" shader `shaders/patternv0.35_bloom.wgsl` (channel invert toggle, white center island, studio dim + UV ring); also includes previous bloom helpers in `utils/bloomPostProcessor.ts`.
 
 - Play tracker modules in the browser using libopenmpt (WASM).
-- Pattern view with two modes: HTML fallback and optional WebGPU (WGSL shaders included in /shaders).
+- Pattern view with three renderer backends: **WebGPU** (WGSL shaders), **WebGL2** (GLSL reference renderer), and **HTML** fallback.
 - Simple media panel & overlay for images, GIFs, and videos synchronized with playback.
 - Built with Vite, React, and TypeScript. Tailwind CSS is used for styling.
 
@@ -17,7 +17,7 @@ Quick start
 Prerequisites
 
 - Node.js (16+ recommended) and npm or a compatible package manager.
-- A modern browser. WebGPU pattern rendering requires a browser with WebGPU support (e.g. recent Chrome/Edge with the flag enabled or experimental builds).
+- A modern browser. WebGPU is the default renderer (Chrome 113+, Edge 113+, Arc). WebGL2 and HTML fallbacks work in any modern browser.
 
 Install dependencies
 
@@ -44,7 +44,11 @@ Usage
 
 - Click "Load" or drag-and-drop a tracker module file (.mod, .it, .s3m, .xm, etc.) to load it.
 - Use the playback controls to play/stop and toggle looping.
-- Toggle the pattern view between HTML and WGSL (WebGPU) when your browser supports it.
+- Switch pattern renderers via URL param, debug panel, or devtools:
+  - `?renderer=webgpu` (default when available)
+  - `?renderer=webgl2` — GLSL 3.00 ES reference renderer for debugging and CI screenshots
+  - `?renderer=html` — lightweight DOM grid (`PatternSequencer`)
+  - `window.DEBUG_RENDERER = 'webgl2'` or `localStorage.setItem('xasm1_pattern_renderer', 'webgl2')`
 - Add media files via the media panel to display them in the overlay while a module plays.
 
 Project structure (important files)
@@ -53,6 +57,7 @@ Project structure (important files)
 - `index.tsx`, `App.tsx` — React entry and main application UI.
 - `hooks/useLibOpenMPT.ts` — primary integration with the libopenmpt runtime and playback state.
 - `components/` — UI components (Controls, Header, PatternDisplay, PatternSequencer, MediaPanel, etc.).
+- `src/renderers/` — Pattern renderer abstraction (`webgl2/`, `html/`, selection + global API).
 - `shaders/` — WGSL shader files used by the WebGPU pattern renderer.
 - `public/` — static assets.
 - `package.json` — scripts and dependency list. Uses Vite for dev and build.
@@ -61,7 +66,8 @@ Notes and configuration
 
 - libopenmpt: The project loads libopenmpt from an external script (see `index.html`). If you're working offline or need a local copy, host the `libopenmptjs.js` and its WASM assets locally and update `index.html` accordingly.
 - Tailwind: A CDN helper script is present in `index.html` to bring in utility styles quickly in development. For production builds you may want to use the PostCSS/Tailwind config in the repo.
-- WebGPU: WGSL shaders are provided, but WebGPU support varies between browsers and platforms. If WebGPU is not available, the app falls back to an HTML pattern renderer.
+- **Pattern renderers:** WebGPU → WebGL2 → HTML automatic fallback chain. Use WebGL2 (`?renderer=webgl2`) to iterate on shader/effect logic with GLSL and `window.currentPatternRenderer.readPixels()` for Playwright pixel tests. Alt+D (dev) cycles WebGL2 debug modes (wireframe, UV, playhead heatmap).
+- **WebGPU → WebGL2 porting:** Shared packing lives in `utils/gpuPacking.ts`; WebGL2 GLSL mirrors `hooks/webGLShaders.ts` (three-emitter lens caps). Chassis/night mode/bloom approximations are in `src/renderers/webgl2/shaders/`.
 
 Contributing
 

--- a/components/PatternDisplay.tsx
+++ b/components/PatternDisplay.tsx
@@ -3,6 +3,15 @@ import { ChannelShadowState, PatternMatrix, PlaybackState } from '../types';
 
 import { useWebGLOverlay } from '../hooks/useWebGLOverlay';
 import { useWebGPURender, type WebGPURenderParams, type DebugInfo } from '../hooks/useWebGPURender';
+import { useWebGL2PatternRender } from '../src/renderers/webgl2/useWebGL2PatternRender';
+import { PatternHTMLFallback } from '../src/renderers/html/PatternHTMLFallback';
+import {
+  resolvePatternRenderer,
+  subscribeRendererPreference,
+  setRendererOverride,
+} from '../src/renderers/rendererSelection';
+import { setCurrentPatternRenderer } from '../src/renderers/global';
+import type { PatternRendererBackend } from '../src/renderers/types';
 import { BloomPostProcessor } from '../utils/bloomPostProcessor';
 import { WEBGL_HYBRID_SHADERS, supportsStepsLength } from '../utils/shaderVersion';
 import { getShaderMeta } from '../utils/shaderRegistry';
@@ -130,6 +139,10 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
   const themeBlendRef = useRef<number>(nightModeEnabled ? 1.0 : 0.0);
 
   const [webgpuAvailable, setWebgpuAvailable] = useState(true);
+  const [webgl2Available, setWebgl2Available] = useState(true);
+  const [activeBackend, setActiveBackend] = useState<PatternRendererBackend>(() => resolvePatternRenderer());
+
+  useEffect(() => subscribeRendererPreference(setActiveBackend), []);
   const [localTime, setLocalTime] = useState(0);
   const [invertChannels, setInvertChannels] = useState(false);
   // Internal stepsLength state — used when the prop is not controlled by the parent.
@@ -161,7 +174,10 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
 
   const numChannels = matrix?.numChannels ?? DEFAULT_CHANNELS;
 
-  const isOverlayActive = !liteMode && WEBGL_HYBRID_SHADERS.has(shaderFile);
+  const useWebGPU = activeBackend === 'webgpu';
+  const useWebGL2 = activeBackend === 'webgl2';
+  const useHTML = activeBackend === 'html';
+  const isOverlayActive = useWebGPU && !liteMode && WEBGL_HYBRID_SHADERS.has(shaderFile);
 
   const padTopChannel = shaderFile.includes('v0.16') || shaderFile.includes('v0.17') || shaderFile.includes('v0.21') || shaderFile.includes('v0.38') || shaderFile.includes('v0.39') || shaderFile.includes('v0.40') || shaderFile.includes('v0.42') || shaderFile.includes('v0.43') || shaderFile.includes('v0.44') || shaderFile.includes('v0.45') || shaderFile.includes('v0.46') || shaderFile.includes('v0.47') || shaderFile.includes('v0.48') || shaderFile.includes('v0.49') || shaderFile.includes('v0.50') || shaderFile.includes('v0.51') || shaderFile.includes('v0.55');
 
@@ -325,18 +341,53 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
   // explicit deps, guaranteeing the cells buffer is rebuilt when a new module is loaded.
   const oscTextureRef = useRef<GPUTexture | null>(null);
 
-  const { gpuReady, render, deviceRef: gpuDevRef } = useWebGPURender(
+  const { gpuReady, render: renderWebGPU, deviceRef: gpuDevRef } = useWebGPURender(
     canvasRef, glCanvasRef, shaderFile,
     syncCanvasSize, renderParamsRef, matrix, padTopChannel, setDebugInfo, setWebgpuAvailable,
     bloomRef,
     oscTextureRef,
     liteMode,
+    useWebGPU,
   );
+
+  const { glReady, render: renderWebGL2 } = useWebGL2PatternRender(
+    canvasRef, shaderFile,
+    syncCanvasSize, renderParamsRef, matrix, padTopChannel, setDebugInfo, setWebgl2Available,
+    liteMode,
+    crtEnabledRef,
+    useWebGL2,
+  );
+
+  const gpuReadyEffective = useWebGPU ? gpuReady : useWebGL2 ? glReady : false;
+  const render = useWebGPU ? renderWebGPU : useWebGL2 ? renderWebGL2 : () => {};
 
   // Keep resize reconfiguration refs in sync
   useEffect(() => {
     gpuDeviceRef.current = gpuDevRef.current;
   });
+
+  // Expose WebGPU renderer handle for agent/CI pixel tests
+  useEffect(() => {
+    if (!useWebGPU || !gpuReady) return;
+    const canvas = canvasRef.current;
+    setCurrentPatternRenderer({
+      backend: 'webgpu',
+      readPixels: () => {
+        if (!canvas) return null;
+        const gl = canvas.getContext('webgl2');
+        // WebGPU canvas — readback requires copyTextureToBuffer; return null for now
+        void gl;
+        return null;
+      },
+      getCanvas: () => canvas,
+      setDebugMode: () => {},
+      getDebugMode: () => 'normal',
+      setScrollSpeed: () => {},
+      getScrollSpeed: () => 1,
+      resize: () => handleResize(),
+    });
+    return () => setCurrentPatternRenderer(null);
+  }, [useWebGPU, gpuReady, handleResize]);
 
   // Create oscilloscope 1D texture when GPU is ready and v0.55 is active
   useEffect(() => {
@@ -359,7 +410,7 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
   useEffect(() => {
     const device = gpuDevRef.current;
     const canvas = canvasRef.current;
-    if (!device || !canvas || !gpuReady) return;
+    if (!device || !canvas || !gpuReady || !useWebGPU) return;
     if (liteMode) return; // Skip bloom entirely in lite mode
     const context = canvas.getContext('webgpu') as GPUCanvasContext | null;
     if (!context) return;
@@ -383,7 +434,7 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
       bloomRef.current?.destroy();
       bloomRef.current = null;
     };
-  }, [gpuReady, shaderFile, liteMode]);
+  }, [gpuReady, shaderFile, liteMode, useWebGPU]);
 
   // DEV: Alt+B cycles bloom layer isolation (trigger → sustain → expression/trace → all)
   useEffect(() => {
@@ -504,8 +555,10 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
           { width: 2048, height: 1, depthOrArrayLayers: 1 }
         );
       }
-      if (gpuReady) {
-        bloomRef.current?.updateCRT(crtEnabledRef.current ? 1.0 : 0.0);
+      if (gpuReadyEffective && !useHTML) {
+        if (useWebGPU) {
+          bloomRef.current?.updateCRT(crtEnabledRef.current ? 1.0 : 0.0);
+        }
         renderRef.current?.();
         if (isOverlayActive) drawWebGL();
       }
@@ -515,7 +568,7 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
       isActive = false;
       if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current);
     };
-  }, [isModuleLoaded, isPlaying, gpuReady, drawWebGL]);
+  }, [isModuleLoaded, isPlaying, gpuReadyEffective, drawWebGL, useWebGPU, useHTML, isOverlayActive]);
 
   return (
     <div
@@ -565,24 +618,46 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
         </button>
       )}
 
-      <canvas
-        ref={canvasRef}
-        data-shader-preview-source="true"
-        width={canvasMetrics.width}
-        height={canvasMetrics.height}
-        onClick={handleCanvasClick}
-        className={`${padTopChannel && !shaderFile.includes('v0.40') && !shaderFile.includes('v0.43') && !shaderFile.includes('v0.44') ? 'rounded bg-black shadow-inner border border-black/50' : ''} cursor-pointer`}
-        style={{ width: 'auto', height: 'auto', maxWidth: '100%', maxHeight: '100%', aspectRatio: `${canvasMetrics.width} / ${canvasMetrics.height}`, objectFit: 'contain', position: 'relative' }}
-      />
-      <canvas
-        ref={glCanvasRef}
-        width={canvasMetrics.width}
-        height={canvasMetrics.height}
-        className="absolute top-0 left-0 pointer-events-none"
-        style={{ width: 'auto', height: 'auto', maxWidth: '100%', maxHeight: '100%', aspectRatio: `${canvasMetrics.width} / ${canvasMetrics.height}`, objectFit: 'contain', zIndex: 2, position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', display: isOverlayActive ? 'block' : 'none' }}
-      />
+      {useHTML ? (
+        <PatternHTMLFallback
+          matrix={matrix}
+          playheadRow={playheadRow}
+          totalRows={totalRows ?? matrix?.numRows ?? 64}
+          bpm={bpm}
+          {...(onSeek ? { onSeek } : {})}
+        />
+      ) : (
+        <>
+          <canvas
+            ref={canvasRef}
+            data-shader-preview-source="true"
+            data-renderer={activeBackend}
+            width={canvasMetrics.width}
+            height={canvasMetrics.height}
+            onClick={handleCanvasClick}
+            className={`${padTopChannel && !shaderFile.includes('v0.40') && !shaderFile.includes('v0.43') && !shaderFile.includes('v0.44') ? 'rounded bg-black shadow-inner border border-black/50' : ''} cursor-pointer`}
+            style={{ width: 'auto', height: 'auto', maxWidth: '100%', maxHeight: '100%', aspectRatio: `${canvasMetrics.width} / ${canvasMetrics.height}`, objectFit: 'contain', position: 'relative' }}
+          />
+          <canvas
+            ref={glCanvasRef}
+            width={canvasMetrics.width}
+            height={canvasMetrics.height}
+            className="absolute top-0 left-0 pointer-events-none"
+            style={{ width: 'auto', height: 'auto', maxWidth: '100%', maxHeight: '100%', aspectRatio: `${canvasMetrics.width} / ${canvasMetrics.height}`, objectFit: 'contain', zIndex: 2, position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', display: isOverlayActive ? 'block' : 'none' }}
+          />
+        </>
+      )}
 
-      {!webgpuAvailable && <div className="error">WebGPU not available in this browser.</div>}
+      {!useHTML && useWebGPU && !webgpuAvailable && (
+        <div className="error absolute inset-0 flex items-center justify-center bg-black/80 text-red-400 text-sm font-mono p-4">
+          WebGPU not available — use <code className="mx-1">?renderer=webgl2</code> or <code className="mx-1">?renderer=html</code>
+        </div>
+      )}
+      {!useHTML && useWebGL2 && !webgl2Available && (
+        <div className="error absolute inset-0 flex items-center justify-center bg-black/80 text-red-400 text-sm font-mono p-4">
+          WebGL2 not available — use <code className="mx-1">?renderer=html</code>
+        </div>
+      )}
 
       {!debugPanelOpen && (
         <button
@@ -601,11 +676,33 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
             <button onClick={onCloseDebug} className="text-gray-500 hover:text-white">✕</button>
           </div>
           <div className="mb-2">
-            <span className="text-gray-400">Mode:</span>
+            <span className="text-gray-400">Renderer:</span>
+            <select
+              value={activeBackend}
+              onChange={(e) => {
+                const next = e.target.value as PatternRendererBackend;
+                setRendererOverride(next);
+                persistRendererPreference(next);
+                setActiveBackend(next);
+              }}
+              className="ml-2 bg-[#111] border border-green-500/40 text-green-300 rounded px-1 py-0.5 text-[10px]"
+            >
+              <option value="webgpu">webgpu</option>
+              <option value="webgl2">webgl2</option>
+              <option value="html">html</option>
+            </select>
+          </div>
+          <div className="mb-2">
+            <span className="text-gray-400">Layout:</span>
             <span className={`ml-2 font-bold ${debugInfo.layoutMode.includes('32') ? 'text-blue-400' : debugInfo.layoutMode.includes('64') ? 'text-purple-400' : 'text-orange-400'}`}>
               {debugInfo.layoutMode}
             </span>
           </div>
+          {import.meta.env.DEV && activeBackend === 'webgl2' && (
+            <div className="mb-2 text-[10px] text-yellow-300">
+              Alt+D cycles debug modes (wireframe, UV, playhead…)
+            </div>
+          )}
           {debugInfo.errors.length > 0 && (
             <div className="mb-2">
               <div className="text-red-400 font-bold mb-1">Errors:</div>

--- a/components/PatternDisplay.tsx
+++ b/components/PatternDisplay.tsx
@@ -682,7 +682,6 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
               onChange={(e) => {
                 const next = e.target.value as PatternRendererBackend;
                 setRendererOverride(next);
-                persistRendererPreference(next);
                 setActiveBackend(next);
               }}
               className="ml-2 bg-[#111] border border-green-500/40 text-green-300 rounded px-1 py-0.5 text-[10px]"

--- a/components/PatternSequencer.tsx
+++ b/components/PatternSequencer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { PatternMatrix } from '../types';
+import { calculateNoteDurations } from '../utils/gpuPacking';
 
 interface PatternSequencerProps {
   matrix: PatternMatrix | null;
@@ -101,6 +102,8 @@ export const PatternSequencer: React.FC<PatternSequencerProps> = ({ matrix, curr
   };
 
   // 4. Always run this useMemo too
+  const durationGrid = useMemo(() => calculateNoteDurations(matrix), [matrix]);
+
   const patternTiles = useMemo(() => {
     if (!matrix) return null;
 
@@ -162,22 +165,36 @@ export const PatternSequencer: React.FC<PatternSequencerProps> = ({ matrix, curr
                       const cells = patternRows[stepIdx] || Array.from({ length: columns }, () => ({ type: 'empty', text: '' }));
                       const cell = cells[chIdx];
                       const cellNote = cell && /[A-G]#?-/i.test(cell.text || '') ? cell.text : '';
+                      const dInfo = durationGrid[stepIdx]?.[chIdx];
+                      const isTrigger = dInfo?.isTrigger ?? false;
+                      const isSustain = dInfo?.isSustained ?? false;
                       const isActive = stepIdx === (currentRow % patternLen);
 
                       let cellColor = 'rgba(60,60,70,0.3)'; // empty/dim
-                      let cellGlow = {};
+                      let cellGlow: React.CSSProperties = {};
+                      let cellScaleY = 1;
 
-                      if (cellNote) {
-                        const hue = noteToHue(cellNote);
-                        const light = octaveToLightness(cellNote);
-                        cellColor = `hsl(${hue} 85% ${light}%)`;
+                      const cellNoteVal = cell && 'note' in cell ? cell.note : undefined;
+                      if (cellNote || (cellNoteVal && cellNoteVal > 0)) {
+                        const noteText = cellNote || `note-${cellNoteVal}`;
+                        const hue = noteToHue(noteText);
+                        const light = isTrigger
+                          ? octaveToLightness(noteText) + 8
+                          : isSustain
+                            ? octaveToLightness(noteText) - 12
+                            : octaveToLightness(noteText);
+                        const sat = isTrigger ? 92 : isSustain ? 55 : 75;
+                        cellColor = `hsl(${hue} ${sat}% ${Math.max(28, light)}%)`;
+                        cellScaleY = isTrigger ? 1.55 : isSustain ? 0.75 : 1.0;
 
-                        if (isActive) {
-                          // Active step: brightest neon glow
-                          cellGlow = { boxShadow: `0 0 16px hsl(${hue} 95% ${light + 5}%)AA, 0 0 32px hsl(${hue} 90% ${light}%)66` };
+                        if (isTrigger) {
+                          cellGlow = { boxShadow: `0 0 18px hsl(${hue} 95% ${light + 10}%)CC, 0 0 28px hsl(195 90% 65%)55` };
+                        } else if (isSustain) {
+                          cellGlow = { boxShadow: `0 0 5px ${cellColor}44` };
+                        } else if (isActive) {
+                          cellGlow = { boxShadow: `0 0 12px hsl(${hue} 90% ${light}%)88` };
                         } else {
-                          // Inactive but has note: subtle glow
-                          cellGlow = { boxShadow: `0 0 6px ${cellColor}55` };
+                          cellGlow = { boxShadow: `0 0 4px ${cellColor}40` };
                         }
                       } else if (isActive) {
                         // Active but empty: white/neutral glow
@@ -199,8 +216,8 @@ export const PatternSequencer: React.FC<PatternSequencerProps> = ({ matrix, curr
                           style={{
                             background: cellColor,
                             ...cellGlow,
-                            transform: isActive ? 'scaleY(1.3)' : undefined,
-                            opacity: cellNote ? (isActive ? 1 : 0.75) : (isActive ? 0.6 : 0.3),
+                            transform: `scaleY(${isActive ? Math.max(cellScaleY, 1.2) : cellScaleY})`,
+                            opacity: (cellNote || cellNoteVal) ? (isTrigger ? 1 : isSustain ? 0.55 : isActive ? 0.9 : 0.7) : (isActive ? 0.6 : 0.3),
                             minWidth: 4,
                             maxWidth: 20,
                           }}

--- a/grok.md
+++ b/grok.md
@@ -11,7 +11,7 @@
 ## Technology Stack (Summary)
 - React 18 + TypeScript + Vite
 - libopenmpt (WASM) via AudioWorklet (JS + optional native C++)
-- WebGPU + WGSL (pattern visualizer, bloom, chassis)
+- WebGPU + WGSL (pattern visualizer, bloom, chassis); WebGL2 GLSL reference renderer (`?renderer=webgl2`); HTML fallback
 - Three.js / React Three Fiber (optional 3D mode)
 - Tailwind + custom CSS variables
 
@@ -20,6 +20,13 @@
 - Shader versioning logic in PatternDisplay.tsx is load-bearing — do not refactor lightly
 - Data packing (Uint32Array) must stay in sync with WGSL shaders
 - COOP/COEP headers required for SharedArrayBuffer + WASM workers
+
+## Pattern Renderer Backends
+- **webgpu** (default): production WGSL shaders via `hooks/useWebGPURender.ts`
+- **webgl2**: GLSL 3.00 ES in `src/renderers/webgl2/` — use for shader porting, Playwright pixel tests (`window.currentPatternRenderer.readPixels()`), debug modes (Alt+D in dev)
+- **html**: DOM grid via `PatternSequencer` — `?renderer=html`
+
+Shared data packing: `utils/gpuPacking.ts`. WebGL2 lens-cap GLSL mirrors `hooks/webGLShaders.ts`.
 
 ## Grok Guidelines
 - **Respect the existing structure**: The AGENTS.md and CLAUDE.md already contain deep technical detail. Use them as primary reference.

--- a/hooks/useWebGPURender.ts
+++ b/hooks/useWebGPURender.ts
@@ -112,6 +112,7 @@ export function useWebGPURender(
   bloomProcessorRef?: React.MutableRefObject<BloomPostProcessor | null>,
   oscTextureRef?: React.MutableRefObject<GPUTexture | null>,
   liteMode?: boolean,
+  enabled = true,
 ) {
   const [gpuReady, setGpuReady] = useState(false);
 
@@ -251,6 +252,10 @@ export function useWebGPURender(
 
   // Main WebGPU initialization
   useEffect(() => {
+    if (!enabled) {
+      setGpuReady(false);
+      return;
+    }
     const canvas = canvasRef.current;
     if (!canvas) return;
     if (!('gpu' in navigator)) { setWebgpuAvailable(false); return; }
@@ -460,7 +465,7 @@ export function useWebGPURender(
       deviceRef.current = null;
       contextRef.current = null;
     };
-  }, [shaderFile, syncCanvasSize]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [shaderFile, syncCanvasSize, enabled]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update cells buffer when matrix changes.
   // Uses `matrix` and `padTopChannel` as direct React deps (not via renderParamsRef) so React

--- a/hooks/webGLShaders.ts
+++ b/hooks/webGLShaders.ts
@@ -421,7 +421,8 @@ export function buildFragmentShader(useNoteSustainTailMode: boolean, isV021: boo
         uint rowOffset = (durationFlags >> 1u) & 63u;
         bool isNoteOffFlag = (durationFlags & 1u) != 0u;
         bool isSustaining = hasNote && (durationRaw > 1u) && (rowOffset > 0u) && !isNoteOffFlag;
-        bool isNoteOnRow = hasNote && (rowOffset == 0u);
+        bool is_trigger = ((packedB & 0x8000u) != 0u) || (rowOffset == 0u && hasNote && !isNoteOffFlag);
+        bool isNoteOnRow = is_trigger && hasNote;
         // 0.0 at note start → 1.0 at note end; used to fade trail glow
         float sustainProgress = (durationRaw > 1u) ? float(rowOffset) / float(durationRaw) : 0.0;
 
@@ -494,17 +495,16 @@ export function buildFragmentShader(useNoteSustainTailMode: boolean, isV021: boo
             if (hasNote && !isExpressionOnly) {
                 float pitchHue = pitchClassFromIndex(note);
                 noteColor = neonPalette(pitchHue);
-                if (isNoteOnRow) {
-                    // Strong glow for note-on
-                    midIntensity = 0.6 + bloom * 2.0;
+                if (is_trigger) {
+                    // TRIG-001: trigger node — large, brilliant
+                    midIntensity = 1.0 + bloom * 2.5;
                     if (USE_NOTE_SUSTAIN_TAIL_MODE && v_active > 0.0) {
-                        midIntensity = max(midIntensity, 0.6 + v_active * (0.8 + bloom));
+                        midIntensity = max(midIntensity, 0.8 + v_active * (1.0 + bloom));
                     }
                 } else if (isSustaining && !USE_NOTE_SUSTAIN_TAIL_MODE) {
-                    // Sustain: fades from 0.5 (note start) to 0.25 (note end)
-                    // Clamped to 0.15 minimum for a dim ringing glow
-                    float sustainBright = 0.5 - sustainProgress * 0.25;
-                    midIntensity = max(sustainBright, 0.15);
+                    // Sustain tail — smaller, dimmer
+                    float sustainBright = 0.35 - sustainProgress * 0.15;
+                    midIntensity = max(sustainBright, 0.12);
                 }
                 if (isMuted) midIntensity *= 0.3;
             }
@@ -527,8 +527,11 @@ export function buildFragmentShader(useNoteSustainTailMode: boolean, isV021: boo
             botColor = amberColor * (1.5 + bloom * 2.0);
         }
 
-        // Draw unified lens cap
-        vec2 lensSize = vec2(0.6, 0.82);
+        // TRIG-001: trigger nodes larger; sustain tails smaller
+        vec2 triggerLens = vec2(0.72, 0.92);
+        vec2 sustainLens = vec2(0.44, 0.58);
+        vec2 defaultLens = vec2(0.6, 0.82);
+        vec2 lensSize = is_trigger ? triggerLens : (isSustaining ? sustainLens : defaultLens);
         vec4 lens = drawUnifiedLensCap(
             lensUV, lensSize,
             vec4(topColor, topIntensity),

--- a/public/shaders/compute_note_duration.wgsl
+++ b/public/shaders/compute_note_duration.wgsl
@@ -213,10 +213,14 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
                    ((duration & 0xFFu) << 8u) |
                    (volPacked & 0xFFu);
 
-        let outB = ((outEffCmd & 0xFFu) << 24u) |
+        var outB = ((outEffCmd & 0xFFu) << 24u) |
                    ((outEffVal & 0xFFu) << 16u) |
                    ((durationFlags & 0x7Fu) << 8u) |
                    (outVolCmd & 0xFFu);
+        // TRIG-001: explicit trigger flag on note-on rows
+        if (rowOffset == 0u && !isNoteOffFlag) {
+            outB = outB | 0x8000u;
+        }
 
         outputCells[idx]     = outA;
         outputCells[idx + 1u] = outB;

--- a/public/shaders/patternv0.47.wgsl
+++ b/public/shaders/patternv0.47.wgsl
@@ -190,6 +190,25 @@ struct FragmentConstants {
   housingSize: vec2<f32>,
 };
 
+// TRIG-001: Duration + trigger metadata (high-precision packing)
+struct NoteDurationInfo {
+  duration: u32,
+  rowOffset: u32,
+  isNoteOff: bool,
+  isTrigger: bool,
+}
+
+fn unpackDurationInfo(packedA: u32, packedB: u32) -> NoteDurationInfo {
+  var info: NoteDurationInfo;
+  info.duration = (packedA >> 8) & 0xFFu;
+  if (info.duration == 0u) { info.duration = 1u; }
+  let durationFlags = (packedB >> 8) & 0x7Fu;
+  info.rowOffset = durationFlags >> 1u;
+  info.isNoteOff = (durationFlags & 1u) != 0u;
+  info.isTrigger = ((packedB & 0x8000u) != 0u) || (info.rowOffset == 0u && !info.isNoteOff);
+  return info;
+}
+
 fn getFragmentConstants() -> FragmentConstants {
   var c: FragmentConstants;
   c.bgColor = vec3<f32>(0.04, 0.04, 0.05);
@@ -399,41 +418,61 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     let topLed = drawFrostedGlassCap(topUV, topSize, topColor, isActive, aa, select(0.0, 1.0, isActive), topColor, select(0.0, 1.0, isActive));
     finalColor = mix(finalColor, topLed.rgb, topLed.a);
 
-    // COMPONENT 2: MAIN NOTE LIGHT
+    // COMPONENT 2: MAIN NOTE LIGHT — TRIG-001 dual-state (trigger node + sustain tail)
     let mainUV = btnUV - vec2<f32>(0.5, 0.5);
-    let mainSize = vec2<f32>(0.55, 0.45);
+    var mainSize = vec2<f32>(0.55, 0.45);
 
     var noteColor = vec3<f32>(0.15);
     var lightAmount = 0.0;
     var noteGlow = 0.0;
 
-    if (hasNote) {
+    let dInfo = unpackDurationInfo(in.packedA, in.packedB);
+    let hasPitchNote = (noteChar >= 1u) && (noteChar <= 96u);
+    let has_sustain = hasPitchNote && !dInfo.isNoteOff;
+    let is_trigger = dInfo.isTrigger && hasPitchNote;
+    let is_sustain_tail = has_sustain && !is_trigger && dInfo.rowOffset > 0u;
+
+    if (has_sustain) {
       let pitchHue = pitchClassFromPacked(in.packedA);
       let baseColor = selectPalette(uniforms.colorPalette, pitchHue);
       let instBand = inst & 15u;
       let instBright = 0.85 + (select(0.0, f32(instBand) / 15.0, instBand > 0u)) * 0.15;
-      noteColor = baseColor * instBright;
+      let flash = f32(ch.trigger) * select(0.0, 1.4, is_trigger);
+      let strike = playheadActivation * select(0.4, 3.5, is_trigger);
+      let beatBoost = 1.0 + kick * select(0.15, 0.5, is_trigger);
+      let dist = length(mainUV);
 
-      let linger = exp(-ch.noteAge * 1.2);
-      let strike = playheadActivation * 3.5;
-      let flash = f32(ch.trigger) * 1.2;
+      if (is_trigger) {
+        // === TRIGGER NODE: large, brilliant, prominent ===
+        mainSize = vec2<f32>(0.62, 0.52);
+        let trigger_intensity = smoothstep(0.45, 0.0, dist / max(mainSize.x, 0.001));
+        let trigger_color = vec3<f32>(0.3, 0.85, 1.0);
+        noteColor = mix(trigger_color, baseColor * instBright, 0.55);
+        lightAmount = (trigger_intensity * 1.35 + flash + strike) * clamp(ch.volume, 0.0, 1.2) * beatBoost;
+        let bloom_halo = smoothstep(0.7, 0.0, dist / max(mainSize.x, 0.001)) * 0.6;
+        noteColor += trigger_color * bloom_halo;
+      } else if (is_sustain_tail) {
+        // === SUSTAIN TAIL: smaller, dimmer trail ===
+        mainSize = vec2<f32>(0.30, 0.24);
+        let tail_intensity = smoothstep(0.18, 0.0, dist / max(mainSize.x, 0.001)) * 0.65;
+        let tail_color = vec3<f32>(0.15, 0.45, 0.65);
+        let fade = 1.0 - (f32(dInfo.rowOffset) / max(f32(dInfo.duration), 1.0)) * 0.35;
+        noteColor = mix(tail_color, baseColor * instBright * 0.45, 0.35);
+        lightAmount = tail_intensity * fade * clamp(ch.volume, 0.0, 1.0) * 0.55;
+      } else {
+        // Single-row / pluck — treat as trigger-sized but slightly softer
+        mainSize = vec2<f32>(0.50, 0.42);
+        let pluck_intensity = smoothstep(0.38, 0.0, dist / max(mainSize.x, 0.001));
+        noteColor = baseColor * instBright;
+        lightAmount = pluck_intensity * clamp(ch.volume, 0.0, 1.2);
+      }
 
-      let totalSteps = f32(uniforms.numRows);
-      let d = fract((f32(in.row) + uniforms.tickOffset - uniforms.playheadRow) / totalSteps) * totalSteps;
-      let coreDist = min(d, totalSteps - d);
-      let energy = 0.03 / (coreDist + 0.001);
-      let trail = exp(-7.0 * max(0.0, -d));
-      let activeVal = clamp(pow(energy, 1.3) + trail, 0.0, 1.0);
-
-      // Beat-reactive: brighter pulse on kick
-      let beatBoost = 1.0 + kick * 0.5;
-      lightAmount = (activeVal * 0.9 + flash + strike + (linger * 2.5)) * clamp(ch.volume, 0.0, 1.2) * beatBoost;
       if (isMuted) { lightAmount *= 0.2; }
       noteGlow = lightAmount;
     }
 
-    let displayColor = noteColor * max(lightAmount, 0.12) * (1.0 + bloom * 8.0);
-    let isLit = (lightAmount > 0.05);
+    let displayColor = noteColor * max(lightAmount, 0.08) * (1.0 + bloom * select(4.0, 8.0, is_trigger));
+    let isLit = (lightAmount > 0.04);
     let mainPad = drawFrostedGlassCap(mainUV, mainSize, displayColor, isLit, aa, noteGlow, displayColor, noteGlow);
     finalColor = mix(finalColor, mainPad.rgb, mainPad.a);
 

--- a/public/shaders/patternv0.50.wgsl
+++ b/public/shaders/patternv0.50.wgsl
@@ -239,6 +239,7 @@ struct NoteDurationInfo {
   duration: u32,      // Total note duration in rows
   rowOffset: u32,     // How many rows from note start (0 = note-on)
   isNoteOff: bool,    // Whether this cell is the note-off row
+  isTrigger: bool,    // TRIG-001: explicit note-on trigger row
 }
 
 // DURA: Unpack duration info from packed cell data
@@ -253,6 +254,7 @@ fn unpackDurationInfo(packedA: u32, packedB: u32) -> NoteDurationInfo {
   let durationFlags = (packedB >> 8) & 0x7Fu;
   info.rowOffset = durationFlags >> 1u;
   info.isNoteOff = (durationFlags & 1u) != 0u;
+  info.isTrigger = ((packedB & 0x8000u) != 0u) || (info.rowOffset == 0u && !info.isNoteOff);
 
   return info;
 }
@@ -589,11 +591,11 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     dInfo.rowOffset = durationFlags >> 1u;
     dInfo.isNoteOff = (durationFlags & 1u) != 0u;
 
-    // AMBER-BLUE: Cell-type classification
-    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.rowOffset == 0u);
+    // AMBER-BLUE: Cell-type classification (TRIG-001 trigger vs sustain tail)
+    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.isTrigger);
     let isNoteOff  = (note >= NOTE_OFF_MIN);
     let isExprOnly = (!isNoteOn && !isNoteOff && isExpressionOnly);
-    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && dInfo.duration > 1u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
+    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && !dInfo.isTrigger && dInfo.duration > 0u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
     let isDead     = (!isNoteOn && !isExprOnly && !isSustain && !isNoteOff);
 
     let ch = channels[in.channel];
@@ -628,10 +630,11 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
       noteColor = baseColor * instBright * octBright;
 
       if (isNoteOn) {
-        midIntensity = calculateSustainBrightness(dInfo, 0.8 + bloom * 2.0);
+        // Trigger node: full brightness + bloom halo
+        midIntensity = calculateSustainBrightness(dInfo, 1.1 + bloom * 2.5);
       } else {
-        // Sustain tail: fixed ~45% intensity
-        midIntensity = 0.45 + bloom * 0.5;
+        // Sustain tail: dimmer, thinner visual weight
+        midIntensity = 0.32 + bloom * 0.35;
       }
       if (isMuted) { midIntensity *= 0.25; }
     } else if (isNoteOff) {
@@ -662,7 +665,10 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
 
     // --- DRAW UNIFIED LENS CAP ---
     let lensUV = btnUV - vec2<f32>(0.5, 0.5);
-    let lensSize = vec2<f32>(0.6, 0.82);
+    // TRIG-001: trigger nodes are larger/brighter; sustain tails are smaller
+    let triggerLens = vec2<f32>(0.72, 0.92);
+    let sustainLens = vec2<f32>(0.44, 0.58);
+    let lensSize = select(sustainLens, triggerLens, isNoteOn);
 
     let unifiedLens = drawUnifiedLensCap(
         lensUV, lensSize,

--- a/public/shaders/patternv0.51.wgsl
+++ b/public/shaders/patternv0.51.wgsl
@@ -223,6 +223,7 @@ struct NoteDurationInfo {
   duration: u32,      // Total note duration in rows
   rowOffset: u32,     // How many rows from note start (0 = note-on)
   isNoteOff: bool,    // Whether this cell is the note-off row
+  isTrigger: bool,    // TRIG-001: explicit note-on trigger row
 }
 
 // DURA: Unpack duration info from packed cell data
@@ -237,6 +238,7 @@ fn unpackDurationInfo(packedA: u32, packedB: u32) -> NoteDurationInfo {
   let durationFlags = (packedB >> 8) & 0x7Fu;
   info.rowOffset = durationFlags >> 1u;
   info.isNoteOff = (durationFlags & 1u) != 0u;
+  info.isTrigger = ((packedB & 0x8000u) != 0u) || (info.rowOffset == 0u && !info.isNoteOff);
   
   return info;
 }
@@ -601,10 +603,10 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     dInfo.isNoteOff = (durationFlags & 1u) != 0u;
 
     // AMBER-BLUE: Cell-type classification
-    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.rowOffset == 0u);
+    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.isTrigger);
     let isNoteOff  = (note >= NOTE_OFF_MIN);
     let isExprOnly = (!isNoteOn && !isNoteOff && isExpressionOnly);
-    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && dInfo.duration > 1u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
+    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && !dInfo.isTrigger && dInfo.duration > 0u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
     let isDead     = (!isNoteOn && !isExprOnly && !isSustain && !isNoteOff);
 
     let ch = channels[in.channel];
@@ -639,10 +641,9 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
       noteColor = baseColor * instBright * octBright;
 
       if (isNoteOn) {
-        midIntensity = calculateSustainBrightness(dInfo, 0.8 + bloom * 2.0);
+        midIntensity = calculateSustainBrightness(dInfo, 1.1 + bloom * 2.5);
       } else {
-        // Sustain tail: fixed ~45% intensity
-        midIntensity = 0.45 + bloom * 0.5;
+        midIntensity = 0.32 + bloom * 0.35;
       }
       if (isMuted) { midIntensity *= 0.25; }
     } else if (isNoteOff) {
@@ -673,7 +674,9 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     
     // --- DRAW UNIFIED LENS CAP ---
     let lensUV = btnUV - vec2<f32>(0.5, 0.5);
-    let lensSize = vec2<f32>(0.6, 0.82);
+    let triggerLens = vec2<f32>(0.72, 0.92);
+    let sustainLens = vec2<f32>(0.44, 0.58);
+    let lensSize = select(sustainLens, triggerLens, isNoteOn);
     
     let unifiedLens = drawUnifiedLensCap(
         lensUV, lensSize,

--- a/public/shaders/patternv0.55.wgsl
+++ b/public/shaders/patternv0.55.wgsl
@@ -205,6 +205,7 @@ struct NoteDurationInfo {
   duration: u32,      // Total note duration in rows
   rowOffset: u32,     // How many rows from note start (0 = note-on)
   isNoteOff: bool,    // Whether this cell is the note-off row
+  isTrigger: bool,    // TRIG-001: explicit note-on trigger row
 }
 
 // DURA: Unpack duration info from packed cell data
@@ -219,6 +220,7 @@ fn unpackDurationInfo(packedA: u32, packedB: u32) -> NoteDurationInfo {
   let durationFlags = (packedB >> 8) & 0x7Fu;
   info.rowOffset = durationFlags >> 1u;
   info.isNoteOff = (durationFlags & 1u) != 0u;
+  info.isTrigger = ((packedB & 0x8000u) != 0u) || (info.rowOffset == 0u && !info.isNoteOff);
   
   return info;
 }
@@ -597,10 +599,10 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     dInfo.isNoteOff = (durationFlags & 1u) != 0u;
 
     // AMBER-BLUE: Cell-type classification
-    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.rowOffset == 0u);
+    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.isTrigger);
     let isNoteOff  = (note >= NOTE_OFF_MIN);
     let isExprOnly = (!isNoteOn && !isNoteOff && isExpressionOnly);
-    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && dInfo.duration > 1u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
+    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && !dInfo.isTrigger && dInfo.duration > 0u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
     let isDead     = (!isNoteOn && !isExprOnly && !isSustain && !isNoteOff);
 
     let ch = channels[in.channel];
@@ -635,10 +637,9 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
       noteColor = baseColor * instBright * octBright;
 
       if (isNoteOn) {
-        midIntensity = calculateSustainBrightness(dInfo, 0.8 + bloom * 2.0);
+        midIntensity = calculateSustainBrightness(dInfo, 1.1 + bloom * 2.5);
       } else {
-        // Sustain tail: fixed ~45% intensity
-        midIntensity = 0.45 + bloom * 0.5;
+        midIntensity = 0.32 + bloom * 0.35;
       }
       if (isMuted) { midIntensity *= 0.25; }
     } else if (isNoteOff) {
@@ -669,7 +670,9 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     
     // --- DRAW UNIFIED LENS CAP ---
     let lensUV = btnUV - vec2<f32>(0.5, 0.5);
-    let lensSize = vec2<f32>(0.6, 0.82);
+    let triggerLens = vec2<f32>(0.72, 0.92);
+    let sustainLens = vec2<f32>(0.44, 0.58);
+    let lensSize = select(sustainLens, triggerLens, isNoteOn);
     
     let unifiedLens = drawUnifiedLensCap(
         lensUV, lensSize,

--- a/shaders/README.md
+++ b/shaders/README.md
@@ -120,7 +120,7 @@ PackedB = [Reserved(16) | EffectCmd(8) | EffectVal(8)]
 ## Performance & Compatibility
 
 - **WebGPU Requirement:** Chrome 113+, Edge 113+, Arc, or other WebGPU-enabled browsers
-- **Fallback:** If WebGPU is unavailable, the app renders an HTML grid fallback
+- **Fallbacks:** WebGPU → WebGL2 (`?renderer=webgl2`, GLSL reference) → HTML (`?renderer=html`)
 - **Canvas Sizes:** Most shaders use 1024×1024; legacy (v0.25–v0.26) use 2048×2016
 - **Bloom Pipeline:** Uses separate threshold, blur, and composite passes
 

--- a/shaders/compute_note_duration.wgsl
+++ b/shaders/compute_note_duration.wgsl
@@ -213,10 +213,14 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
                    ((duration & 0xFFu) << 8u) |
                    (volPacked & 0xFFu);
 
-        let outB = ((outEffCmd & 0xFFu) << 24u) |
+        var outB = ((outEffCmd & 0xFFu) << 24u) |
                    ((outEffVal & 0xFFu) << 16u) |
                    ((durationFlags & 0x7Fu) << 8u) |
                    (outVolCmd & 0xFFu);
+        // TRIG-001: explicit trigger flag on note-on rows
+        if (rowOffset == 0u && !isNoteOffFlag) {
+            outB = outB | 0x8000u;
+        }
 
         outputCells[idx]     = outA;
         outputCells[idx + 1u] = outB;

--- a/shaders/patternv0.47.wgsl
+++ b/shaders/patternv0.47.wgsl
@@ -190,6 +190,25 @@ struct FragmentConstants {
   housingSize: vec2<f32>,
 };
 
+// TRIG-001: Duration + trigger metadata (high-precision packing)
+struct NoteDurationInfo {
+  duration: u32,
+  rowOffset: u32,
+  isNoteOff: bool,
+  isTrigger: bool,
+}
+
+fn unpackDurationInfo(packedA: u32, packedB: u32) -> NoteDurationInfo {
+  var info: NoteDurationInfo;
+  info.duration = (packedA >> 8) & 0xFFu;
+  if (info.duration == 0u) { info.duration = 1u; }
+  let durationFlags = (packedB >> 8) & 0x7Fu;
+  info.rowOffset = durationFlags >> 1u;
+  info.isNoteOff = (durationFlags & 1u) != 0u;
+  info.isTrigger = ((packedB & 0x8000u) != 0u) || (info.rowOffset == 0u && !info.isNoteOff);
+  return info;
+}
+
 fn getFragmentConstants() -> FragmentConstants {
   var c: FragmentConstants;
   c.bgColor = vec3<f32>(0.04, 0.04, 0.05);
@@ -399,41 +418,61 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     let topLed = drawFrostedGlassCap(topUV, topSize, topColor, isActive, aa, select(0.0, 1.0, isActive), topColor, select(0.0, 1.0, isActive));
     finalColor = mix(finalColor, topLed.rgb, topLed.a);
 
-    // COMPONENT 2: MAIN NOTE LIGHT
+    // COMPONENT 2: MAIN NOTE LIGHT — TRIG-001 dual-state (trigger node + sustain tail)
     let mainUV = btnUV - vec2<f32>(0.5, 0.5);
-    let mainSize = vec2<f32>(0.55, 0.45);
+    var mainSize = vec2<f32>(0.55, 0.45);
 
     var noteColor = vec3<f32>(0.15);
     var lightAmount = 0.0;
     var noteGlow = 0.0;
 
-    if (hasNote) {
+    let dInfo = unpackDurationInfo(in.packedA, in.packedB);
+    let hasPitchNote = (noteChar >= 1u) && (noteChar <= 96u);
+    let has_sustain = hasPitchNote && !dInfo.isNoteOff;
+    let is_trigger = dInfo.isTrigger && hasPitchNote;
+    let is_sustain_tail = has_sustain && !is_trigger && dInfo.rowOffset > 0u;
+
+    if (has_sustain) {
       let pitchHue = pitchClassFromPacked(in.packedA);
       let baseColor = selectPalette(uniforms.colorPalette, pitchHue);
       let instBand = inst & 15u;
       let instBright = 0.85 + (select(0.0, f32(instBand) / 15.0, instBand > 0u)) * 0.15;
-      noteColor = baseColor * instBright;
+      let flash = f32(ch.trigger) * select(0.0, 1.4, is_trigger);
+      let strike = playheadActivation * select(0.4, 3.5, is_trigger);
+      let beatBoost = 1.0 + kick * select(0.15, 0.5, is_trigger);
+      let dist = length(mainUV);
 
-      let linger = exp(-ch.noteAge * 1.2);
-      let strike = playheadActivation * 3.5;
-      let flash = f32(ch.trigger) * 1.2;
+      if (is_trigger) {
+        // === TRIGGER NODE: large, brilliant, prominent ===
+        mainSize = vec2<f32>(0.62, 0.52);
+        let trigger_intensity = smoothstep(0.45, 0.0, dist / max(mainSize.x, 0.001));
+        let trigger_color = vec3<f32>(0.3, 0.85, 1.0);
+        noteColor = mix(trigger_color, baseColor * instBright, 0.55);
+        lightAmount = (trigger_intensity * 1.35 + flash + strike) * clamp(ch.volume, 0.0, 1.2) * beatBoost;
+        let bloom_halo = smoothstep(0.7, 0.0, dist / max(mainSize.x, 0.001)) * 0.6;
+        noteColor += trigger_color * bloom_halo;
+      } else if (is_sustain_tail) {
+        // === SUSTAIN TAIL: smaller, dimmer trail ===
+        mainSize = vec2<f32>(0.30, 0.24);
+        let tail_intensity = smoothstep(0.18, 0.0, dist / max(mainSize.x, 0.001)) * 0.65;
+        let tail_color = vec3<f32>(0.15, 0.45, 0.65);
+        let fade = 1.0 - (f32(dInfo.rowOffset) / max(f32(dInfo.duration), 1.0)) * 0.35;
+        noteColor = mix(tail_color, baseColor * instBright * 0.45, 0.35);
+        lightAmount = tail_intensity * fade * clamp(ch.volume, 0.0, 1.0) * 0.55;
+      } else {
+        // Single-row / pluck — treat as trigger-sized but slightly softer
+        mainSize = vec2<f32>(0.50, 0.42);
+        let pluck_intensity = smoothstep(0.38, 0.0, dist / max(mainSize.x, 0.001));
+        noteColor = baseColor * instBright;
+        lightAmount = pluck_intensity * clamp(ch.volume, 0.0, 1.2);
+      }
 
-      let totalSteps = f32(uniforms.numRows);
-      let d = fract((f32(in.row) + uniforms.tickOffset - uniforms.playheadRow) / totalSteps) * totalSteps;
-      let coreDist = min(d, totalSteps - d);
-      let energy = 0.03 / (coreDist + 0.001);
-      let trail = exp(-7.0 * max(0.0, -d));
-      let activeVal = clamp(pow(energy, 1.3) + trail, 0.0, 1.0);
-
-      // Beat-reactive: brighter pulse on kick
-      let beatBoost = 1.0 + kick * 0.5;
-      lightAmount = (activeVal * 0.9 + flash + strike + (linger * 2.5)) * clamp(ch.volume, 0.0, 1.2) * beatBoost;
       if (isMuted) { lightAmount *= 0.2; }
       noteGlow = lightAmount;
     }
 
-    let displayColor = noteColor * max(lightAmount, 0.12) * (1.0 + bloom * 8.0);
-    let isLit = (lightAmount > 0.05);
+    let displayColor = noteColor * max(lightAmount, 0.08) * (1.0 + bloom * select(4.0, 8.0, is_trigger));
+    let isLit = (lightAmount > 0.04);
     let mainPad = drawFrostedGlassCap(mainUV, mainSize, displayColor, isLit, aa, noteGlow, displayColor, noteGlow);
     finalColor = mix(finalColor, mainPad.rgb, mainPad.a);
 

--- a/shaders/patternv0.50.wgsl
+++ b/shaders/patternv0.50.wgsl
@@ -239,6 +239,7 @@ struct NoteDurationInfo {
   duration: u32,      // Total note duration in rows
   rowOffset: u32,     // How many rows from note start (0 = note-on)
   isNoteOff: bool,    // Whether this cell is the note-off row
+  isTrigger: bool,    // TRIG-001: explicit note-on trigger row
 }
 
 // DURA: Unpack duration info from packed cell data
@@ -253,6 +254,7 @@ fn unpackDurationInfo(packedA: u32, packedB: u32) -> NoteDurationInfo {
   let durationFlags = (packedB >> 8) & 0x7Fu;
   info.rowOffset = durationFlags >> 1u;
   info.isNoteOff = (durationFlags & 1u) != 0u;
+  info.isTrigger = ((packedB & 0x8000u) != 0u) || (info.rowOffset == 0u && !info.isNoteOff);
 
   return info;
 }
@@ -589,11 +591,11 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     dInfo.rowOffset = durationFlags >> 1u;
     dInfo.isNoteOff = (durationFlags & 1u) != 0u;
 
-    // AMBER-BLUE: Cell-type classification
-    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.rowOffset == 0u);
+    // AMBER-BLUE: Cell-type classification (TRIG-001 trigger vs sustain tail)
+    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.isTrigger);
     let isNoteOff  = (note >= NOTE_OFF_MIN);
     let isExprOnly = (!isNoteOn && !isNoteOff && isExpressionOnly);
-    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && dInfo.duration > 1u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
+    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && !dInfo.isTrigger && dInfo.duration > 0u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
     let isDead     = (!isNoteOn && !isExprOnly && !isSustain && !isNoteOff);
 
     let ch = channels[in.channel];
@@ -628,10 +630,11 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
       noteColor = baseColor * instBright * octBright;
 
       if (isNoteOn) {
-        midIntensity = calculateSustainBrightness(dInfo, 0.8 + bloom * 2.0);
+        // Trigger node: full brightness + bloom halo
+        midIntensity = calculateSustainBrightness(dInfo, 1.1 + bloom * 2.5);
       } else {
-        // Sustain tail: fixed ~45% intensity
-        midIntensity = 0.45 + bloom * 0.5;
+        // Sustain tail: dimmer, thinner visual weight
+        midIntensity = 0.32 + bloom * 0.35;
       }
       if (isMuted) { midIntensity *= 0.25; }
     } else if (isNoteOff) {
@@ -662,7 +665,10 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
 
     // --- DRAW UNIFIED LENS CAP ---
     let lensUV = btnUV - vec2<f32>(0.5, 0.5);
-    let lensSize = vec2<f32>(0.6, 0.82);
+    // TRIG-001: trigger nodes are larger/brighter; sustain tails are smaller
+    let triggerLens = vec2<f32>(0.72, 0.92);
+    let sustainLens = vec2<f32>(0.44, 0.58);
+    let lensSize = select(sustainLens, triggerLens, isNoteOn);
 
     let unifiedLens = drawUnifiedLensCap(
         lensUV, lensSize,

--- a/shaders/patternv0.51.wgsl
+++ b/shaders/patternv0.51.wgsl
@@ -223,6 +223,7 @@ struct NoteDurationInfo {
   duration: u32,      // Total note duration in rows
   rowOffset: u32,     // How many rows from note start (0 = note-on)
   isNoteOff: bool,    // Whether this cell is the note-off row
+  isTrigger: bool,    // TRIG-001: explicit note-on trigger row
 }
 
 // DURA: Unpack duration info from packed cell data
@@ -237,6 +238,7 @@ fn unpackDurationInfo(packedA: u32, packedB: u32) -> NoteDurationInfo {
   let durationFlags = (packedB >> 8) & 0x7Fu;
   info.rowOffset = durationFlags >> 1u;
   info.isNoteOff = (durationFlags & 1u) != 0u;
+  info.isTrigger = ((packedB & 0x8000u) != 0u) || (info.rowOffset == 0u && !info.isNoteOff);
   
   return info;
 }
@@ -601,10 +603,10 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     dInfo.isNoteOff = (durationFlags & 1u) != 0u;
 
     // AMBER-BLUE: Cell-type classification
-    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.rowOffset == 0u);
+    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.isTrigger);
     let isNoteOff  = (note >= NOTE_OFF_MIN);
     let isExprOnly = (!isNoteOn && !isNoteOff && isExpressionOnly);
-    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && dInfo.duration > 1u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
+    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && !dInfo.isTrigger && dInfo.duration > 0u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
     let isDead     = (!isNoteOn && !isExprOnly && !isSustain && !isNoteOff);
 
     let ch = channels[in.channel];
@@ -639,10 +641,9 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
       noteColor = baseColor * instBright * octBright;
 
       if (isNoteOn) {
-        midIntensity = calculateSustainBrightness(dInfo, 0.8 + bloom * 2.0);
+        midIntensity = calculateSustainBrightness(dInfo, 1.1 + bloom * 2.5);
       } else {
-        // Sustain tail: fixed ~45% intensity
-        midIntensity = 0.45 + bloom * 0.5;
+        midIntensity = 0.32 + bloom * 0.35;
       }
       if (isMuted) { midIntensity *= 0.25; }
     } else if (isNoteOff) {
@@ -673,7 +674,9 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     
     // --- DRAW UNIFIED LENS CAP ---
     let lensUV = btnUV - vec2<f32>(0.5, 0.5);
-    let lensSize = vec2<f32>(0.6, 0.82);
+    let triggerLens = vec2<f32>(0.72, 0.92);
+    let sustainLens = vec2<f32>(0.44, 0.58);
+    let lensSize = select(sustainLens, triggerLens, isNoteOn);
     
     let unifiedLens = drawUnifiedLensCap(
         lensUV, lensSize,

--- a/shaders/patternv0.55.wgsl
+++ b/shaders/patternv0.55.wgsl
@@ -205,6 +205,7 @@ struct NoteDurationInfo {
   duration: u32,      // Total note duration in rows
   rowOffset: u32,     // How many rows from note start (0 = note-on)
   isNoteOff: bool,    // Whether this cell is the note-off row
+  isTrigger: bool,    // TRIG-001: explicit note-on trigger row
 }
 
 // DURA: Unpack duration info from packed cell data
@@ -219,6 +220,7 @@ fn unpackDurationInfo(packedA: u32, packedB: u32) -> NoteDurationInfo {
   let durationFlags = (packedB >> 8) & 0x7Fu;
   info.rowOffset = durationFlags >> 1u;
   info.isNoteOff = (durationFlags & 1u) != 0u;
+  info.isTrigger = ((packedB & 0x8000u) != 0u) || (info.rowOffset == 0u && !info.isNoteOff);
   
   return info;
 }
@@ -597,10 +599,10 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     dInfo.isNoteOff = (durationFlags & 1u) != 0u;
 
     // AMBER-BLUE: Cell-type classification
-    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.rowOffset == 0u);
+    let isNoteOn   = (note > 0u && note < NOTE_OFF_MIN && dInfo.isTrigger);
     let isNoteOff  = (note >= NOTE_OFF_MIN);
     let isExprOnly = (!isNoteOn && !isNoteOff && isExpressionOnly);
-    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && dInfo.duration > 1u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
+    let isSustain  = (note > 0u && note < NOTE_OFF_MIN && !dInfo.isTrigger && dInfo.duration > 0u && dInfo.rowOffset > 0u && !dInfo.isNoteOff);
     let isDead     = (!isNoteOn && !isExprOnly && !isSustain && !isNoteOff);
 
     let ch = channels[in.channel];
@@ -635,10 +637,9 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
       noteColor = baseColor * instBright * octBright;
 
       if (isNoteOn) {
-        midIntensity = calculateSustainBrightness(dInfo, 0.8 + bloom * 2.0);
+        midIntensity = calculateSustainBrightness(dInfo, 1.1 + bloom * 2.5);
       } else {
-        // Sustain tail: fixed ~45% intensity
-        midIntensity = 0.45 + bloom * 0.5;
+        midIntensity = 0.32 + bloom * 0.35;
       }
       if (isMuted) { midIntensity *= 0.25; }
     } else if (isNoteOff) {
@@ -669,7 +670,9 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     
     // --- DRAW UNIFIED LENS CAP ---
     let lensUV = btnUV - vec2<f32>(0.5, 0.5);
-    let lensSize = vec2<f32>(0.6, 0.82);
+    let triggerLens = vec2<f32>(0.72, 0.92);
+    let sustainLens = vec2<f32>(0.44, 0.58);
+    let lensSize = select(sustainLens, triggerLens, isNoteOn);
     
     let unifiedLens = drawUnifiedLensCap(
         lensUV, lensSize,

--- a/src/renderers/global.ts
+++ b/src/renderers/global.ts
@@ -1,0 +1,13 @@
+import type { CurrentPatternRenderer } from './types';
+
+declare global {
+  interface Window {
+    currentPatternRenderer: CurrentPatternRenderer | null;
+  }
+}
+
+export function setCurrentPatternRenderer(handle: CurrentPatternRenderer | null): void {
+  if (typeof window !== 'undefined') {
+    window.currentPatternRenderer = handle;
+  }
+}

--- a/src/renderers/html/PatternHTMLFallback.tsx
+++ b/src/renderers/html/PatternHTMLFallback.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react';
+import { PatternSequencer } from '../../../components/PatternSequencer';
+import type { PatternMatrix } from '../../../types';
+import { setCurrentPatternRenderer } from '../global';
+import type { CurrentPatternRenderer } from '../types';
+
+interface PatternHTMLFallbackProps {
+  matrix: PatternMatrix | null;
+  playheadRow: number;
+  totalRows?: number;
+  bpm?: number;
+  onSeek?: (row: number) => void;
+}
+
+/**
+ * Lightweight DOM pattern grid — ultimate fallback when GPU backends are unavailable
+ * or when `?renderer=html` is set.
+ */
+export const PatternHTMLFallback: React.FC<PatternHTMLFallbackProps> = ({
+  matrix,
+  playheadRow,
+  totalRows = 0,
+  bpm = 120,
+  onSeek,
+}) => {
+  useEffect(() => {
+    const handle: CurrentPatternRenderer = {
+      backend: 'html',
+      readPixels: () => null,
+      getCanvas: () => null,
+      setDebugMode: () => {},
+      getDebugMode: () => 'normal',
+      setScrollSpeed: () => {},
+      getScrollSpeed: () => 1,
+      resize: () => {},
+    };
+    setCurrentPatternRenderer(handle);
+    return () => setCurrentPatternRenderer(null);
+  }, []);
+
+  return (
+    <div className="pattern-html-fallback w-full h-full overflow-auto bg-[#0a0a0c] p-2">
+      <PatternSequencer
+        matrix={matrix}
+        currentRow={Math.floor(playheadRow)}
+        globalRow={Math.floor(playheadRow)}
+        totalRows={totalRows}
+        bpm={bpm}
+        {...(onSeek ? { onSeek } : {})}
+      />
+    </div>
+  );
+};

--- a/src/renderers/rendererSelection.ts
+++ b/src/renderers/rendererSelection.ts
@@ -1,0 +1,109 @@
+import type { PatternRendererBackend } from './types';
+
+const STORAGE_KEY = 'xasm1_pattern_renderer';
+const VALID_BACKENDS: ReadonlySet<PatternRendererBackend> = new Set(['webgpu', 'webgl2', 'html']);
+
+/** Global runtime override — set from devtools or tests: `window.DEBUG_RENDERER = 'webgl2'`. */
+declare global {
+  interface Window {
+    DEBUG_RENDERER?: PatternRendererBackend;
+  }
+}
+
+function parseBackend(value: string | null | undefined): PatternRendererBackend | null {
+  if (!value) return null;
+  const normalized = value.toLowerCase() as PatternRendererBackend;
+  return VALID_BACKENDS.has(normalized) ? normalized : null;
+}
+
+/** Read preferred backend from URL `?renderer=`, localStorage, or `window.DEBUG_RENDERER`. */
+export function readRendererPreference(): PatternRendererBackend | null {
+  if (typeof window === 'undefined') return null;
+
+  const fromGlobal = parseBackend(window.DEBUG_RENDERER);
+  if (fromGlobal) return fromGlobal;
+
+  const urlParam = parseBackend(new URLSearchParams(window.location.search).get('renderer'));
+  if (urlParam) return urlParam;
+
+  try {
+    return parseBackend(localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return null;
+  }
+}
+
+/** Persist renderer choice (survives reload; hot-reload picks it up on next HMR cycle). */
+export function persistRendererPreference(backend: PatternRendererBackend): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, backend);
+  } catch {
+    // private browsing / quota — ignore
+  }
+}
+
+export function clearRendererPreference(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function isWebGPUAvailable(): boolean {
+  return typeof navigator !== 'undefined' && 'gpu' in navigator;
+}
+
+export function isWebGL2Available(): boolean {
+  if (typeof document === 'undefined') return false;
+  const canvas = document.createElement('canvas');
+  return !!canvas.getContext('webgl2');
+}
+
+/**
+ * Resolve the effective backend with automatic fallback:
+ * webgpu → webgl2 → html
+ */
+export function resolvePatternRenderer(
+  preference: PatternRendererBackend | null = readRendererPreference(),
+): PatternRendererBackend {
+  const want = preference ?? 'webgpu';
+
+  if (want === 'html') return 'html';
+
+  if (want === 'webgl2') {
+    return isWebGL2Available() ? 'webgl2' : 'html';
+  }
+
+  // Default / explicit webgpu
+  if (isWebGPUAvailable()) return 'webgpu';
+  if (isWebGL2Available()) return 'webgl2';
+  return 'html';
+}
+
+/** Subscribe to renderer preference changes (storage events + custom events). */
+export function subscribeRendererPreference(
+  onChange: (backend: PatternRendererBackend) => void,
+): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const handler = () => onChange(resolvePatternRenderer());
+
+  window.addEventListener('storage', handler);
+  window.addEventListener('xasm1-renderer-change', handler);
+
+  return () => {
+    window.removeEventListener('storage', handler);
+    window.removeEventListener('xasm1-renderer-change', handler);
+  };
+}
+
+export function notifyRendererPreferenceChanged(): void {
+  window.dispatchEvent(new Event('xasm1-renderer-change'));
+}
+
+export function setRendererOverride(backend: PatternRendererBackend): void {
+  window.DEBUG_RENDERER = backend;
+  persistRendererPreference(backend);
+  notifyRendererPreferenceChanged();
+}

--- a/src/renderers/types.ts
+++ b/src/renderers/types.ts
@@ -1,0 +1,43 @@
+import type { WebGPURenderParams } from '../../hooks/useWebGPURender';
+
+/** Active pattern visualization backend. */
+export type PatternRendererBackend = 'webgpu' | 'webgl2' | 'html';
+
+/** Shared per-frame parameters — all GPU backends read the same ref. */
+export type PatternRenderParams = WebGPURenderParams;
+
+/** Debug visualization modes for the WebGL2 reference renderer. */
+export type WebGL2DebugMode =
+  | 'normal'
+  | 'wireframe'
+  | 'uv'
+  | 'playhead'
+  | 'channels'
+  | 'note-data';
+
+export interface WebGL2DebugConfig {
+  mode: WebGL2DebugMode;
+  /** Multiplier for playhead-driven scrolling (0.25 = quarter speed). */
+  scrollSpeed: number;
+  /** When true, skip bloom post-processing. */
+  skipBloom: boolean;
+}
+
+export const DEFAULT_WEBGL2_DEBUG: WebGL2DebugConfig = {
+  mode: 'normal',
+  scrollSpeed: 1.0,
+  skipBloom: false,
+};
+
+/** Agent/CI-facing handle exposed on `window.currentPatternRenderer`. */
+export interface CurrentPatternRenderer {
+  backend: PatternRendererBackend;
+  /** Read back RGBA pixels from the active canvas (bottom-left origin). */
+  readPixels(): Uint8Array | null;
+  getCanvas(): HTMLCanvasElement | null;
+  setDebugMode(mode: WebGL2DebugMode): void;
+  getDebugMode(): WebGL2DebugMode;
+  setScrollSpeed(speed: number): void;
+  getScrollSpeed(): number;
+  resize(): void;
+}

--- a/src/renderers/webgl2/WebGL2Bloom.ts
+++ b/src/renderers/webgl2/WebGL2Bloom.ts
@@ -1,0 +1,184 @@
+import {
+  FULLSCREEN_VERTEX,
+  BLUR_FRAGMENT,
+  COMPOSITE_FRAGMENT,
+} from './shaders/bloom';
+
+function compileShader(gl: WebGL2RenderingContext, type: number, source: string): WebGLShader {
+  const shader = gl.createShader(type)!;
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(shader) ?? 'unknown';
+    gl.deleteShader(shader);
+    throw new Error(`Bloom shader compile failed: ${log}`);
+  }
+  return shader;
+}
+
+function linkProgram(gl: WebGL2RenderingContext, vs: WebGLShader, fs: WebGLShader): WebGLProgram {
+  const program = gl.createProgram()!;
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const log = gl.getProgramInfoLog(program) ?? 'unknown';
+    gl.deleteProgram(program);
+    throw new Error(`Bloom program link failed: ${log}`);
+  }
+  return program;
+}
+
+type FBO = { fbo: WebGLFramebuffer; texture: WebGLTexture };
+
+/**
+ * Lightweight 2-pass separable bloom for the WebGL2 reference renderer.
+ * Mirrors the intent of utils/bloomPostProcessor.ts without WebGPU dependencies.
+ */
+export class WebGL2Bloom {
+  private gl: WebGL2RenderingContext;
+  private width = 0;
+  private height = 0;
+  private quadVao: WebGLVertexArrayObject;
+  private quadBuffer: WebGLBuffer;
+  private blurProgram: WebGLProgram;
+  private compositeProgram: WebGLProgram;
+  private sceneFbo: FBO | null = null;
+  private pingFbo: FBO | null = null;
+  private pongFbo: FBO | null = null;
+  private threshold = 0.8;
+  private intensity = 1.0;
+  private crtEnabled = 0.0;
+
+  constructor(gl: WebGL2RenderingContext) {
+    this.gl = gl;
+    this.quadVao = gl.createVertexArray()!;
+    this.quadBuffer = gl.createBuffer()!;
+    gl.bindVertexArray(this.quadVao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.quadBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+    const vs = compileShader(gl, gl.VERTEX_SHADER, FULLSCREEN_VERTEX);
+    this.blurProgram = linkProgram(gl, vs, compileShader(gl, gl.FRAGMENT_SHADER, BLUR_FRAGMENT));
+    this.compositeProgram = linkProgram(gl, vs, compileShader(gl, gl.FRAGMENT_SHADER, COMPOSITE_FRAGMENT));
+  }
+
+  resize(width: number, height: number): void {
+    if (width === this.width && height === this.height) return;
+    this.destroyFbos();
+    this.width = width;
+    this.height = height;
+    this.sceneFbo = this.createFbo(width, height);
+    this.pingFbo = this.createFbo(width, height);
+    this.pongFbo = this.createFbo(width, height);
+  }
+
+  setBloomParams(intensity: number, threshold: number): void {
+    this.intensity = intensity;
+    this.threshold = threshold;
+  }
+
+  setCRT(enabled: boolean): void {
+    this.crtEnabled = enabled ? 1.0 : 0.0;
+  }
+
+  /** Returns the scene FBO to render the pattern pass into. */
+  bindSceneTarget(): void {
+    const gl = this.gl;
+    if (!this.sceneFbo) return;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.sceneFbo.fbo);
+    gl.viewport(0, 0, this.width, this.height);
+  }
+
+  /** Blur scene → composite to default framebuffer. */
+  compositeToScreen(): void {
+    const gl = this.gl;
+    if (!this.sceneFbo || !this.pingFbo || !this.pongFbo) return;
+
+    const texel = [1 / this.width, 1 / this.height];
+
+    // Horizontal blur: scene → ping
+    this.runBlur(this.sceneFbo.texture, this.pingFbo, [1, 0], texel);
+    // Vertical blur: ping → pong
+    this.runBlur(this.pingFbo.texture, this.pongFbo, [0, 1], texel);
+
+    // Composite to screen
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.viewport(0, 0, this.width, this.height);
+    gl.useProgram(this.compositeProgram);
+    gl.bindVertexArray(this.quadVao);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.sceneFbo.texture);
+    gl.uniform1i(gl.getUniformLocation(this.compositeProgram, 'u_scene')!, 0);
+
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this.pongFbo.texture);
+    gl.uniform1i(gl.getUniformLocation(this.compositeProgram, 'u_bloom')!, 1);
+
+    gl.uniform1f(gl.getUniformLocation(this.compositeProgram, 'u_bloomIntensity')!, this.intensity);
+    gl.uniform1f(gl.getUniformLocation(this.compositeProgram, 'u_crtEnabled')!, this.crtEnabled);
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+  }
+
+  private runBlur(
+    source: WebGLTexture,
+    target: FBO,
+    direction: [number, number],
+    texel: number[],
+  ): void {
+    const gl = this.gl;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, target.fbo);
+    gl.viewport(0, 0, this.width, this.height);
+    gl.useProgram(this.blurProgram);
+    gl.bindVertexArray(this.quadVao);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, source);
+    gl.uniform1i(gl.getUniformLocation(this.blurProgram, 'u_source')!, 0);
+    gl.uniform2f(gl.getUniformLocation(this.blurProgram, 'u_direction')!, direction[0], direction[1]);
+    gl.uniform2f(gl.getUniformLocation(this.blurProgram, 'u_texelSize')!, texel[0]!, texel[1]!);
+    gl.uniform1f(gl.getUniformLocation(this.blurProgram, 'u_threshold')!, this.threshold);
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+  }
+
+  private createFbo(width: number, height: number): FBO {
+    const gl = this.gl;
+    const texture = gl.createTexture()!;
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    const fbo = gl.createFramebuffer()!;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    return { fbo, texture };
+  }
+
+  private destroyFbos(): void {
+    const gl = this.gl;
+    for (const entry of [this.sceneFbo, this.pingFbo, this.pongFbo]) {
+      if (!entry) continue;
+      gl.deleteFramebuffer(entry.fbo);
+      gl.deleteTexture(entry.texture);
+    }
+    this.sceneFbo = null;
+    this.pingFbo = null;
+    this.pongFbo = null;
+  }
+
+  destroy(): void {
+    this.destroyFbos();
+    const gl = this.gl;
+    gl.deleteProgram(this.blurProgram);
+    gl.deleteProgram(this.compositeProgram);
+    gl.deleteVertexArray(this.quadVao);
+    gl.deleteBuffer(this.quadBuffer);
+  }
+}

--- a/src/renderers/webgl2/WebGL2PatternRenderer.ts
+++ b/src/renderers/webgl2/WebGL2PatternRenderer.ts
@@ -1,0 +1,475 @@
+import type { ChannelShadowState } from '../../../types';
+import type { WebGPURenderParams } from '../../../hooks/useWebGPURender';
+import type { WebGL2DebugConfig } from '../types';
+import { packPatternMatrixHighPrecision } from '../../../utils/gpuPacking';
+import {
+  GRID_RECT,
+  calculateHorizontalCellSize,
+  calculateCapScale,
+  getLayoutModeFromShader,
+  LAYOUT_MODES,
+} from '../../../utils/geometryConstants';
+import { getShaderMeta } from '../../../utils/shaderRegistry';
+import { detectRuntimeBase } from '../../../src/lib/paths';
+import { CHASSIS_VERTEX, CHASSIS_FRAGMENT } from './shaders/chassis';
+import { buildVertexShader, buildPatternFragmentShader } from './shaders/pattern';
+import { WebGL2Bloom } from './WebGL2Bloom';
+import { debugModeToUniform, createDebugConfig } from './debugModes';
+
+const DEFAULT_ROWS = 64;
+const DEFAULT_CHANNELS = 4;
+
+type GLProgram = {
+  program: WebGLProgram;
+  uniforms: Record<string, WebGLUniformLocation | null>;
+};
+
+type PatternResources = {
+  program: WebGLProgram;
+  vao: WebGLVertexArrayObject;
+  buffer: WebGLBuffer;
+  cellTexture: WebGLTexture;
+  stateTexture: WebGLTexture;
+  capTexture: WebGLTexture;
+  uniforms: Record<string, WebGLUniformLocation | null>;
+};
+
+function compileShader(gl: WebGL2RenderingContext, type: number, src: string, label: string): WebGLShader {
+  const s = gl.createShader(type)!;
+  gl.shaderSource(s, src);
+  gl.compileShader(s);
+  if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(s) ?? 'unknown';
+    gl.deleteShader(s);
+    throw new Error(`${label} shader error: ${log}`);
+  }
+  return s;
+}
+
+function linkProgram(gl: WebGL2RenderingContext, vs: WebGLShader, fs: WebGLShader, label: string): WebGLProgram {
+  const p = gl.createProgram()!;
+  gl.attachShader(p, vs);
+  gl.attachShader(p, fs);
+  gl.linkProgram(p);
+  if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+    const log = gl.getProgramInfoLog(p) ?? 'unknown';
+    gl.deleteProgram(p);
+    throw new Error(`${label} link error: ${log}`);
+  }
+  return p;
+}
+
+function collectUniforms(gl: WebGL2RenderingContext, program: WebGLProgram, names: string[]): Record<string, WebGLUniformLocation | null> {
+  const out: Record<string, WebGLUniformLocation | null> = {};
+  for (const n of names) out[n] = gl.getUniformLocation(program, n);
+  return out;
+}
+
+/**
+ * Full-scene WebGL2 pattern renderer — reference implementation for WebGPU WGSL shaders.
+ * Renders chassis background + instanced LED lens caps + optional bloom.
+ */
+export class WebGL2PatternRenderer {
+  private gl: WebGL2RenderingContext | null = null;
+  private canvas: HTMLCanvasElement | null = null;
+  private chassis: GLProgram | null = null;
+  private chassisVao: WebGLVertexArrayObject | null = null;
+  private chassisBuffer: WebGLBuffer | null = null;
+  private pattern: PatternResources | null = null;
+  private bloom: WebGL2Bloom | null = null;
+  private stateData = new Float32Array(0);
+  private shaderFile = '';
+  private debug: WebGL2DebugConfig = createDebugConfig();
+  private scrollOffset = 0;
+  private lastTimeSec = 0;
+  init(canvas: HTMLCanvasElement, shaderFile: string): boolean {
+    this.destroy();
+    const gl = canvas.getContext('webgl2', { alpha: false, premultipliedAlpha: false, antialias: true });
+    if (!gl) return false;
+
+    this.gl = gl;
+    this.canvas = canvas;
+    this.shaderFile = shaderFile;
+
+    this.initChassis(gl);
+    this.initPattern(gl, shaderFile);
+    this.bloom = new WebGL2Bloom(gl);
+    this.bloom.resize(canvas.width, canvas.height);
+
+    gl.enable(gl.BLEND);
+    return true;
+  }
+
+  private initChassis(gl: WebGL2RenderingContext): void {
+    const vs = compileShader(gl, gl.VERTEX_SHADER, CHASSIS_VERTEX, 'chassis-vs');
+    const fs = compileShader(gl, gl.FRAGMENT_SHADER, CHASSIS_FRAGMENT, 'chassis-fs');
+    const program = linkProgram(gl, vs, fs, 'chassis');
+    this.chassis = {
+      program,
+      uniforms: collectUniforms(gl, program, [
+        'u_resolution', 'u_timeSec', 'u_dimFactor', 'u_themeBlend',
+        'u_vignetteStrength', 'u_filmGrain', 'u_invertMix', 'u_nightPreset',
+        'u_innerRadius', 'u_outerRadius', 'u_layoutMode',
+      ]),
+    };
+    this.chassisVao = gl.createVertexArray();
+    this.chassisBuffer = gl.createBuffer();
+    gl.bindVertexArray(this.chassisVao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.chassisBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+  }
+
+  private initPattern(gl: WebGL2RenderingContext, shaderFile: string): void {
+    const useNoteSustainTailMode = shaderFile.includes('v0.45b');
+    const isV021 = shaderFile.includes('v0.21');
+    const vsSource = buildVertexShader(useNoteSustainTailMode, isV021);
+    const fsSource = buildPatternFragmentShader(useNoteSustainTailMode, isV021);
+
+    const vs = compileShader(gl, gl.VERTEX_SHADER, vsSource, 'pattern-vs');
+    const fs = compileShader(gl, gl.FRAGMENT_SHADER, fsSource, 'pattern-fs');
+    const program = linkProgram(gl, vs, fs, 'pattern');
+
+    const vao = gl.createVertexArray()!;
+    gl.bindVertexArray(vao);
+    const buffer = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+      -0.5, -0.5, 0.5, -0.5, -0.5, 0.5,
+      -0.5, 0.5, 0.5, -0.5, 0.5, 0.5,
+    ]), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+    const cellTexture = gl.createTexture()!;
+    gl.bindTexture(gl.TEXTURE_2D, cellTexture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+
+    const stateTexture = gl.createTexture()!;
+    gl.bindTexture(gl.TEXTURE_2D, stateTexture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+
+    const capTexture = gl.createTexture()!;
+    gl.bindTexture(gl.TEXTURE_2D, capTexture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+
+    const capImg = new Image();
+    capImg.onload = () => {
+      if (!this.gl) return;
+      this.gl.bindTexture(this.gl.TEXTURE_2D, capTexture);
+      this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, this.gl.RGBA, this.gl.UNSIGNED_BYTE, capImg);
+    };
+    capImg.src = `${detectRuntimeBase()}unlit-button.png`;
+
+    this.pattern = {
+      program,
+      vao,
+      buffer,
+      cellTexture,
+      stateTexture,
+      capTexture,
+      uniforms: collectUniforms(gl, program, [
+        'u_resolution', 'u_cellSize', 'u_offset', 'u_cols', 'u_rows', 'u_playhead',
+        'u_layoutMode', 'u_invertChannels', 'u_cellData', 'u_channelState',
+        'u_capTexture', 'u_bloomIntensity', 'u_timeSec', 'u_innerRadius', 'u_outerRadius',
+        'u_debugMode',
+      ]),
+    };
+    gl.bindVertexArray(null);
+  }
+
+  resize(width: number, height: number): void {
+    this.bloom?.resize(width, height);
+  }
+
+  setDebugConfig(config: Partial<WebGL2DebugConfig>): void {
+    this.debug = { ...this.debug, ...config };
+  }
+
+  getDebugConfig(): WebGL2DebugConfig {
+    return { ...this.debug };
+  }
+
+  setCRT(enabled: boolean): void {
+    this.bloom?.setCRT(enabled);
+  }
+
+  render(
+    params: WebGPURenderParams,
+    padTopChannel: boolean,
+    liteMode: boolean,
+    onDebug?: (info: { layoutMode: string; uniforms: Record<string, number | string>; errors: string[] }) => void,
+  ): void {
+    const gl = this.gl;
+    const canvas = this.canvas;
+    if (!gl || !canvas || !this.chassis || !this.pattern) return;
+
+    const errors: string[] = [];
+    const uniformVals: Record<string, number | string> = {};
+
+    const useBloom = !this.debug.skipBloom && !liteMode;
+    const meta = getShaderMeta(this.shaderFile);
+    const bloomProfile = meta?.bloomProfile;
+
+    if (useBloom && bloomProfile && this.bloom) {
+      this.bloom.setBloomParams(params.bloomIntensity, params.bloomThreshold);
+      this.bloom.bindSceneTarget();
+    } else {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+      gl.viewport(0, 0, canvas.width, canvas.height);
+    }
+
+    gl.clearColor(0, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    const layoutMode = this.resolveLayoutMode(params);
+    const layoutModeName = layoutMode === LAYOUT_MODES.HORIZONTAL_32 ? '32-STEP'
+      : layoutMode === LAYOUT_MODES.HORIZONTAL_64 ? '64-STEP' : 'CIRCULAR';
+
+    this.drawChassis(gl, params, layoutMode, uniformVals);
+    this.drawPattern(gl, params, padTopChannel, layoutMode, layoutModeName, uniformVals, errors);
+
+    if (useBloom && bloomProfile && this.bloom) {
+      this.bloom.compositeToScreen();
+    }
+
+    onDebug?.({ layoutMode: layoutModeName, uniforms: uniformVals, errors });
+  }
+
+  private resolveLayoutMode(params: WebGPURenderParams): number {
+    const shaderFile = this.shaderFile;
+    let layoutMode = getLayoutModeFromShader(shaderFile);
+    if (shaderFile.includes('v0.21') || shaderFile.includes('v0.39') || shaderFile.includes('v0.40')) {
+      layoutMode = params.stepsLength === 64 ? LAYOUT_MODES.HORIZONTAL_64 : LAYOUT_MODES.HORIZONTAL_32;
+    }
+    return layoutMode;
+  }
+
+  private drawChassis(
+    gl: WebGL2RenderingContext,
+    params: WebGPURenderParams,
+    layoutMode: number,
+    uniformVals: Record<string, number | string>,
+  ): void {
+    const chassis = this.chassis!;
+    const canvas = this.canvas!;
+    const minDim = Math.min(canvas.width, canvas.height);
+
+    gl.useProgram(chassis.program);
+    gl.bindVertexArray(this.chassisVao);
+
+    const setF = (name: string, ...args: [number] | [number, number]) => {
+      const loc = chassis.uniforms[name];
+      if (!loc) return;
+      if (args.length === 1) gl.uniform1f(loc, args[0]!);
+      else gl.uniform2f(loc, args[0]!, args[1]!);
+    };
+    const setI = (name: string, v: number) => {
+      const loc = chassis.uniforms[name];
+      if (loc) gl.uniform1i(loc, v);
+    };
+
+    setF('u_resolution', canvas.width, canvas.height);
+    setF('u_timeSec', params.timeSec || performance.now() / 1000);
+    setF('u_dimFactor', params.dimFactor ?? 1);
+    setF('u_themeBlend', params.themeBlend ?? 0);
+    setF('u_vignetteStrength', params.vignetteStrength ?? 0);
+    setF('u_filmGrain', params.filmGrain ?? 0);
+    setF('u_invertMix', params.invertMix ?? 0);
+    setI('u_nightPreset', params.nightPreset ?? 0);
+    setF('u_innerRadius', minDim * 0.15);
+    setF('u_outerRadius', minDim * 0.45);
+    setI('u_layoutMode', layoutMode === LAYOUT_MODES.CIRCULAR ? 1 : 0);
+
+    uniformVals['chassis_themeBlend'] = (params.themeBlend ?? 0).toFixed(2);
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+    gl.bindVertexArray(null);
+  }
+
+  private drawPattern(
+    gl: WebGL2RenderingContext,
+    params: WebGPURenderParams,
+    padTopChannel: boolean,
+    layoutMode: number,
+    layoutModeName: string,
+    uniformVals: Record<string, number | string>,
+    errors: string[],
+  ): void {
+    const res = this.pattern!;
+    const canvas = this.canvas!;
+    const matrix = params.matrix;
+    if (!matrix) return;
+
+    const rawCols = matrix.numChannels || DEFAULT_CHANNELS;
+    const cols = padTopChannel ? rawCols + 1 : rawCols;
+    const rows = matrix.numRows || DEFAULT_ROWS;
+
+    // Upload cell texture
+    const { packedData } = packPatternMatrixHighPrecision(matrix, padTopChannel);
+    gl.bindTexture(gl.TEXTURE_2D, res.cellTexture);
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG32UI, cols, rows, 0, gl.RG_INTEGER, gl.UNSIGNED_INT, packedData);
+
+    // Upload channel state
+    const requiredSize = cols * 2 * 4;
+    if (this.stateData.length !== requiredSize) {
+      this.stateData = new Float32Array(requiredSize);
+    }
+    const chans = params.channels || [];
+    const startIdx = padTopChannel ? 1 : 0;
+    if (startIdx === 1) {
+      for (let j = 0; j < 4; j++) {
+        this.stateData[j] = 0;
+        this.stateData[cols * 4 + j] = 0;
+      }
+    }
+    for (let i = 0; i < (matrix.numChannels || DEFAULT_CHANNELS); i++) {
+      const ch: ChannelShadowState = chans[i] ?? {
+        volume: 0, pan: 0.5, freq: 440, trigger: 0, noteAge: 1000,
+        activeEffect: 0, effectValue: 0, isMuted: 0,
+      };
+      const colIdx = i + startIdx;
+      const r0 = colIdx * 4;
+      this.stateData[r0] = ch.volume ?? 0;
+      this.stateData[r0 + 1] = ch.pan ?? 0.5;
+      this.stateData[r0 + 2] = ch.freq ?? 440;
+      this.stateData[r0 + 3] = ch.trigger ?? 0;
+      const r1 = (cols + colIdx) * 4;
+      this.stateData[r1] = ch.noteAge ?? 1000;
+      this.stateData[r1 + 1] = ch.activeEffect ?? 0;
+      this.stateData[r1 + 2] = ch.effectValue ?? 0;
+      this.stateData[r1 + 3] = ch.isMuted ?? 0;
+    }
+    gl.bindTexture(gl.TEXTURE_2D, res.stateTexture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, cols, 2, 0, gl.RGBA, gl.FLOAT, this.stateData);
+
+    gl.useProgram(res.program);
+    gl.bindVertexArray(res.vao);
+
+    const livePlayhead = this.resolvePlayhead(params);
+    uniformVals['u_playhead'] = livePlayhead.toFixed(2);
+
+    let effectiveCellW = params.cellWidth;
+    let effectiveCellH = params.cellHeight;
+    let offsetX = 0;
+    let offsetY = 0;
+
+    if (layoutMode === LAYOUT_MODES.HORIZONTAL_32) {
+      const m = calculateHorizontalCellSize(canvas.width, canvas.height, 32, cols);
+      effectiveCellW = m.cellW;
+      effectiveCellH = m.cellH;
+      offsetX = m.offsetX;
+      offsetY = m.offsetY;
+    } else if (layoutMode === LAYOUT_MODES.HORIZONTAL_64) {
+      const m = calculateHorizontalCellSize(canvas.width, canvas.height, 64, cols);
+      effectiveCellW = m.cellW;
+      effectiveCellH = m.cellH;
+      offsetX = m.offsetX;
+      offsetY = m.offsetY;
+    }
+
+    const minDim = Math.min(canvas.width, canvas.height);
+    const innerRadius = minDim * 0.15;
+    const outerRadius = minDim * 0.45;
+
+    const u = res.uniforms;
+    if (u.u_resolution) gl.uniform2f(u.u_resolution, canvas.width, canvas.height);
+    if (u.u_cols) gl.uniform1f(u.u_cols, cols);
+    if (u.u_rows) gl.uniform1f(u.u_rows, rows);
+    if (u.u_playhead) gl.uniform1f(u.u_playhead, livePlayhead);
+    if (u.u_invertChannels) gl.uniform1i(u.u_invertChannels, params.invertChannels ? 1 : 0);
+    if (u.u_bloomIntensity) gl.uniform1f(u.u_bloomIntensity, params.bloomIntensity ?? 1);
+    if (u.u_timeSec) gl.uniform1f(u.u_timeSec, params.timeSec || performance.now() / 1000);
+    if (u.u_innerRadius) gl.uniform1f(u.u_innerRadius, innerRadius);
+    if (u.u_outerRadius) gl.uniform1f(u.u_outerRadius, outerRadius);
+    if (u.u_offset) gl.uniform2f(u.u_offset, offsetX, offsetY);
+    if (u.u_cellSize) gl.uniform2f(u.u_cellSize, effectiveCellW, effectiveCellH);
+    if (u.u_layoutMode) gl.uniform1i(u.u_layoutMode, layoutMode);
+    if (u.u_debugMode) gl.uniform1i(u.u_debugMode, debugModeToUniform(this.debug.mode));
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, res.cellTexture);
+    if (u.u_cellData) gl.uniform1i(u.u_cellData, 0);
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, res.stateTexture);
+    if (u.u_channelState) gl.uniform1i(u.u_channelState, 1);
+    gl.activeTexture(gl.TEXTURE2);
+    gl.bindTexture(gl.TEXTURE_2D, res.capTexture);
+    if (u.u_capTexture) gl.uniform1i(u.u_capTexture, 2);
+
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+    uniformVals['capScale'] = calculateCapScale(effectiveCellW, effectiveCellH, pixelRatio).toFixed(1);
+    uniformVals['GRID_RECT'] = `${GRID_RECT.x}, ${GRID_RECT.y}, ${GRID_RECT.w}, ${GRID_RECT.h}`;
+    uniformVals['renderer'] = 'webgl2';
+    uniformVals['debugMode'] = this.debug.mode;
+
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+
+    const stepsForMode = layoutMode === LAYOUT_MODES.HORIZONTAL_32 ? 32
+      : layoutMode === LAYOUT_MODES.HORIZONTAL_64 ? 64 : 64;
+    const totalInstances = stepsForMode * cols;
+    uniformVals['totalInstances'] = totalInstances;
+    uniformVals['layoutMode'] = layoutModeName;
+
+    gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, totalInstances);
+    gl.bindVertexArray(null);
+
+    const err = gl.getError();
+    if (err !== gl.NO_ERROR) errors.push(`GL error 0x${err.toString(16)}`);
+  }
+
+  private resolvePlayhead(params: WebGPURenderParams): number {
+    const base = params.playbackStateRef?.current?.playheadRow ?? params.playheadRow;
+    if (this.debug.scrollSpeed === 1) return base;
+
+    const now = performance.now() / 1000;
+    if (this.lastTimeSec > 0) {
+      const dt = (now - this.lastTimeSec) * this.debug.scrollSpeed;
+      this.scrollOffset += dt * (params.bpm / 60) * 0.25;
+    }
+    this.lastTimeSec = now;
+    const rows = params.matrix?.numRows ?? DEFAULT_ROWS;
+    return (base + this.scrollOffset) % rows;
+  }
+
+  readPixels(): Uint8Array | null {
+    const gl = this.gl;
+    const canvas = this.canvas;
+    if (!gl || !canvas) return null;
+    const buf = new Uint8Array(canvas.width * canvas.height * 4);
+    gl.readPixels(0, 0, canvas.width, canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    return buf;
+  }
+
+  getCanvas(): HTMLCanvasElement | null {
+    return this.canvas;
+  }
+
+  destroy(): void {
+    const gl = this.gl;
+    if (gl && this.pattern) {
+      gl.deleteProgram(this.pattern.program);
+      gl.deleteVertexArray(this.pattern.vao);
+      gl.deleteBuffer(this.pattern.buffer);
+      gl.deleteTexture(this.pattern.cellTexture);
+      gl.deleteTexture(this.pattern.stateTexture);
+      gl.deleteTexture(this.pattern.capTexture);
+    }
+    if (gl && this.chassis) {
+      gl.deleteProgram(this.chassis.program);
+    }
+    if (gl && this.chassisVao) gl.deleteVertexArray(this.chassisVao);
+    if (gl && this.chassisBuffer) gl.deleteBuffer(this.chassisBuffer);
+    this.bloom?.destroy();
+    this.gl = null;
+    this.canvas = null;
+    this.chassis = null;
+    this.pattern = null;
+    this.bloom = null;
+  }
+}

--- a/src/renderers/webgl2/debugModes.ts
+++ b/src/renderers/webgl2/debugModes.ts
@@ -1,0 +1,30 @@
+import type { WebGL2DebugConfig, WebGL2DebugMode } from '../types';
+import { DEFAULT_WEBGL2_DEBUG } from '../types';
+
+const MODE_TO_INT: Record<WebGL2DebugMode, number> = {
+  normal: 0,
+  wireframe: 1,
+  uv: 2,
+  playhead: 3,
+  channels: 4,
+  'note-data': 5,
+};
+
+export function debugModeToUniform(mode: WebGL2DebugMode): number {
+  return MODE_TO_INT[mode] ?? 0;
+}
+
+export function cycleDebugMode(current: WebGL2DebugMode): WebGL2DebugMode {
+  const order: WebGL2DebugMode[] = [
+    'normal', 'wireframe', 'uv', 'playhead', 'channels', 'note-data',
+  ];
+  const idx = order.indexOf(current);
+  const next = order[(idx + 1) % order.length];
+  return next ?? 'normal';
+}
+
+export function createDebugConfig(
+  partial?: Partial<WebGL2DebugConfig>,
+): WebGL2DebugConfig {
+  return { ...DEFAULT_WEBGL2_DEBUG, ...partial };
+}

--- a/src/renderers/webgl2/shaders/bloom.ts
+++ b/src/renderers/webgl2/shaders/bloom.ts
@@ -1,0 +1,63 @@
+/** Separable Gaussian blur + composite — WebGL2 bloom approximation. */
+
+export const FULLSCREEN_VERTEX = `#version 300 es
+precision highp float;
+in vec2 a_pos;
+out vec2 v_uv;
+void main() {
+  v_uv = a_pos * 0.5 + 0.5;
+  gl_Position = vec4(a_pos, 0.0, 1.0);
+}
+`;
+
+export const BLUR_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 fragColor;
+uniform sampler2D u_source;
+uniform vec2 u_direction;
+uniform vec2 u_texelSize;
+uniform float u_threshold;
+
+void main() {
+  vec3 color = vec3(0.0);
+  float w[5];
+  w[0] = 0.227027; w[1] = 0.1945946; w[2] = 0.1216216; w[3] = 0.054054; w[4] = 0.016216;
+  for (int i = 0; i < 5; i++) {
+    float fi = float(i);
+    vec2 off = u_direction * u_texelSize * fi;
+    vec3 s1 = texture(u_source, v_uv + off).rgb;
+    vec3 s2 = texture(u_source, v_uv - off).rgb;
+    float weight = i == 0 ? w[0] : w[int(fi)];
+    color += (s1 + s2) * weight;
+  }
+  float brightness = max(max(color.r, color.g), color.b);
+  color *= step(u_threshold, brightness);
+  fragColor = vec4(color, 1.0);
+}
+`;
+
+export const COMPOSITE_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 fragColor;
+uniform sampler2D u_scene;
+uniform sampler2D u_bloom;
+uniform float u_bloomIntensity;
+uniform float u_crtEnabled;
+
+void main() {
+  vec3 scene = texture(u_scene, v_uv).rgb;
+  vec3 bloom = texture(u_bloom, v_uv).rgb;
+  vec3 color = scene + bloom * u_bloomIntensity;
+
+  if (u_crtEnabled > 0.5) {
+    float scan = sin(v_uv.y * 800.0) * 0.04;
+    color -= scan;
+    float vig = 1.0 - dot(v_uv - 0.5, v_uv - 0.5) * 1.2;
+    color *= clamp(vig, 0.0, 1.0);
+  }
+
+  fragColor = vec4(color, 1.0);
+}
+`;

--- a/src/renderers/webgl2/shaders/chassis.ts
+++ b/src/renderers/webgl2/shaders/chassis.ts
@@ -1,0 +1,81 @@
+/** Fullscreen chassis / bezel background — approximates WebGPU chassis passes. */
+export const CHASSIS_VERTEX = `#version 300 es
+precision highp float;
+layout(location = 0) in vec2 a_pos;
+out vec2 v_uv;
+void main() {
+  v_uv = a_pos * 0.5 + 0.5;
+  gl_Position = vec4(a_pos, 0.0, 1.0);
+}
+`;
+
+export const CHASSIS_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform vec2 u_resolution;
+uniform float u_timeSec;
+uniform float u_dimFactor;
+uniform float u_themeBlend;
+uniform float u_vignetteStrength;
+uniform float u_filmGrain;
+uniform float u_invertMix;
+uniform int u_nightPreset;
+uniform float u_innerRadius;
+uniform float u_outerRadius;
+uniform int u_layoutMode; // 1=circular
+
+float hash(vec2 p) {
+  return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+void main() {
+  vec2 uv = v_uv;
+  vec2 centered = (uv - 0.5) * 2.0;
+  float aspect = u_resolution.x / max(u_resolution.y, 1.0);
+  centered.x *= aspect;
+
+  // Device body gradient
+  vec3 dayColor = vec3(0.06, 0.06, 0.07);
+  vec3 nightColor = vec3(0.02, 0.025, 0.04);
+  float nightMix = clamp(u_themeBlend, 0.0, 1.0);
+  vec3 base = mix(dayColor, nightColor, nightMix);
+
+  // Subtle brushed-metal radial bands
+  float r = length(centered);
+  float band = sin(r * 40.0 + u_timeSec * 0.2) * 0.015;
+  base += band;
+
+  // Circular donut hole (pattern area)
+  if (u_layoutMode == 1) {
+    float minR = u_innerRadius / min(u_resolution.x, u_resolution.y);
+    float maxR = u_outerRadius / min(u_resolution.x, u_resolution.y);
+    float hole = smoothstep(minR - 0.02, minR, r) * (1.0 - smoothstep(maxR, maxR + 0.04, r));
+    base = mix(base * 0.35, base, hole);
+    // Center island (white donut core for v0.35-style shaders)
+    float centerIsland = 1.0 - smoothstep(0.0, minR * 0.85, r);
+    base = mix(base, vec3(0.92, 0.93, 0.96) * u_dimFactor, centerIsland * 0.35 * nightMix);
+  }
+
+  // Vignette
+  float vig = 1.0 - u_vignetteStrength * r * r * 0.6;
+  base *= vig;
+
+  // Film grain
+  float grain = (hash(uv * u_resolution + u_timeSec) - 0.5) * u_filmGrain;
+  base += grain;
+
+  // Luminance invert mix (night mode)
+  float luma = dot(base, vec3(0.299, 0.587, 0.114));
+  base = mix(base, vec3(1.0 - luma), clamp(u_invertMix, 0.0, 1.0));
+
+  base *= u_dimFactor;
+
+  // Bezel edge highlight
+  float edge = smoothstep(0.92, 0.98, max(abs(centered.x), abs(centered.y)));
+  base += edge * vec3(0.08, 0.09, 0.12);
+
+  fragColor = vec4(base, 1.0);
+}
+`;

--- a/src/renderers/webgl2/shaders/pattern.ts
+++ b/src/renderers/webgl2/shaders/pattern.ts
@@ -1,0 +1,40 @@
+import { buildVertexShader, buildFragmentShader } from '../../../../hooks/webGLShaders';
+
+export { buildVertexShader };
+
+/** Pattern fragment shader with optional debug visualization uniforms. */
+export function buildPatternFragmentShader(
+  useNoteSustainTailMode: boolean,
+  isV021: boolean,
+): string {
+  const base = buildFragmentShader(useNoteSustainTailMode, isV021);
+  return base.replace(
+    'uniform float u_timeSec;',
+    `uniform float u_timeSec;
+    uniform int u_debugMode;`,
+  ).replace(
+    'fragColor = vec4(lens.rgb, lens.a * 0.95);',
+    `vec3 outRgb = lens.rgb;
+    float outA = lens.a * 0.95;
+    if (u_debugMode == 1) {
+      float edge = abs(dFdx(v_uv.x)) + abs(dFdy(v_uv.y));
+      outRgb = vec3(step(0.02, edge));
+      outA = 1.0;
+    } else if (u_debugMode == 2) {
+      outRgb = vec3(v_uv, 0.0);
+      outA = 1.0;
+    } else if (u_debugMode == 3) {
+      outRgb = vec3(v_active * 0.5, v_active > 0.5 ? 1.0 : 0.0, 0.0);
+      outA = 1.0;
+    } else if (u_debugMode == 4) {
+      float ch = v_chState0.x;
+      outRgb = vec3(ch, v_chState0.y, v_chState0.z * 0.001);
+      outA = 1.0;
+    } else if (u_debugMode == 5) {
+      uint n = (v_cell.x >> 24u) & 255u;
+      outRgb = vec3(float(n) / 96.0, float((v_cell.x >> 16u) & 255u) / 255.0, float(v_cell.y & 255u) / 255.0);
+      outA = 1.0;
+    }
+    fragColor = vec4(outRgb, outA);`,
+  );
+}

--- a/src/renderers/webgl2/useWebGL2PatternRender.ts
+++ b/src/renderers/webgl2/useWebGL2PatternRender.ts
@@ -1,0 +1,115 @@
+import { useRef, useEffect, useState, useCallback } from 'react';
+import type React from 'react';
+import type { PatternMatrix } from '../../../types';
+import type { WebGPURenderParams, DebugInfo } from '../../../hooks/useWebGPURender';
+import { WebGL2PatternRenderer } from './WebGL2PatternRenderer';
+import { setCurrentPatternRenderer } from '../global';
+import type { CurrentPatternRenderer, WebGL2DebugMode } from '../types';
+import { cycleDebugMode } from './debugModes';
+
+export function useWebGL2PatternRender(
+  canvasRef: React.RefObject<HTMLCanvasElement>,
+  shaderFile: string,
+  syncCanvasSize: (canvas: HTMLCanvasElement, gl: HTMLCanvasElement | null) => void,
+  renderParamsRef: React.MutableRefObject<WebGPURenderParams>,
+  _matrix: PatternMatrix | null,
+  padTopChannel: boolean,
+  setDebugInfo: React.Dispatch<React.SetStateAction<DebugInfo>>,
+  setWebgl2Available: (v: boolean) => void,
+  liteMode?: boolean,
+  crtEnabledRef?: React.MutableRefObject<boolean>,
+  enabled = true,
+) {
+  const [glReady, setGlReady] = useState(false);
+  const rendererRef = useRef<WebGL2PatternRenderer | null>(null);
+  const padTopRef = useRef(padTopChannel);
+  padTopRef.current = padTopChannel;
+
+  useEffect(() => {
+    if (!enabled) {
+      setGlReady(false);
+      return;
+    }
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    syncCanvasSize(canvas, null);
+    const renderer = new WebGL2PatternRenderer();
+    const ok = renderer.init(canvas, shaderFile);
+    if (!ok) {
+      setWebgl2Available(false);
+      setGlReady(false);
+      return;
+    }
+
+    rendererRef.current = renderer;
+    setWebgl2Available(true);
+    setGlReady(true);
+
+    const handle: CurrentPatternRenderer = {
+      backend: 'webgl2',
+      readPixels: () => renderer.readPixels(),
+      getCanvas: () => renderer.getCanvas(),
+      setDebugMode: (mode: WebGL2DebugMode) => renderer.setDebugConfig({ mode }),
+      getDebugMode: () => renderer.getDebugConfig().mode,
+      setScrollSpeed: (speed: number) => renderer.setDebugConfig({ scrollSpeed: speed }),
+      getScrollSpeed: () => renderer.getDebugConfig().scrollSpeed,
+      resize: () => {
+        const c = canvasRef.current;
+        if (c) renderer.resize(c.width, c.height);
+      },
+    };
+    setCurrentPatternRenderer(handle);
+
+    return () => {
+      renderer.destroy();
+      rendererRef.current = null;
+      setGlReady(false);
+      setCurrentPatternRenderer(null);
+    };
+  }, [shaderFile, canvasRef, syncCanvasSize, setWebgl2Available, enabled]);
+
+  // DEV: Alt+D cycles WebGL2 debug visualization modes
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const handler = (e: KeyboardEvent) => {
+      if (!e.altKey || e.key !== 'd') return;
+      e.preventDefault();
+      const r = rendererRef.current;
+      if (!r) return;
+      const next = cycleDebugMode(r.getDebugConfig().mode);
+      r.setDebugConfig({ mode: next });
+      console.log(`[WebGL2 debug] mode: ${next}`);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const render = useCallback(() => {
+    const renderer = rendererRef.current;
+    const canvas = canvasRef.current;
+    if (!renderer || !canvas || !glReady) return;
+
+    renderer.resize(canvas.width, canvas.height);
+    if (crtEnabledRef) {
+      renderer.setCRT(crtEnabledRef.current);
+    }
+
+    const params = renderParamsRef.current;
+    renderer.render(
+      params,
+      padTopRef.current,
+      liteMode ?? false,
+      (info) => {
+        setDebugInfo((prev) => ({
+          ...prev,
+          layoutMode: info.layoutMode,
+          uniforms: { ...prev.uniforms, ...info.uniforms, backend: 'webgl2' },
+          errors: info.errors,
+        }));
+      },
+    );
+  }, [glReady, liteMode, crtEnabledRef, renderParamsRef, setDebugInfo, canvasRef]);
+
+  return { glReady, render, rendererRef, deviceRef: rendererRef };
+}

--- a/types.ts
+++ b/types.ts
@@ -198,5 +198,9 @@ declare global {
     libopenmpt: LibOpenMPT;
     _libopenmptReject?: (reason: Error) => void;
     webkitAudioContext?: typeof AudioContext;
+    /** Force pattern renderer backend: `webgpu` | `webgl2` | `html` */
+    DEBUG_RENDERER?: 'webgpu' | 'webgl2' | 'html';
+    /** Agent/CI handle — set by the active pattern renderer */
+    currentPatternRenderer: import('./src/renderers/types').CurrentPatternRenderer | null;
   }
 }

--- a/utils/gpuPacking.ts
+++ b/utils/gpuPacking.ts
@@ -20,6 +20,16 @@ const NOTE_MAX = 119;  // Maximum valid note (C0–B9, covers MOD/XM/IT full ran
 /** Any note value ≥ NOTE_OFF_MIN is a note-off, note-cut, or note-fade event. */
 const NOTE_OFF_MIN = 120;
 
+/** Bit 15 of packedB — explicit note-on trigger flag (TRIG-001). */
+export const PACKEDB_TRIGGER_FLAG = 0x8000;
+
+/** Read TRIG-001 trigger flag from packedB. Falls back to rowOffset==0 when bit unset. */
+export const isTriggerFromPackedB = (packedB: number, rowOffset: number, isNoteOff: boolean): boolean => {
+  if (isNoteOff) return false;
+  if ((packedB & PACKEDB_TRIGGER_FLAG) !== 0) return true;
+  return rowOffset === 0;
+};
+
 export const PLAYHEAD_EPSILON = 0.0001;
 
 export const alignTo = (val: number, align: number): number =>
@@ -446,7 +456,9 @@ export const packPatternMatrixHighPrecision = (matrix: PatternMatrix | null, pad
       }
       
       const cell = rowCells[c];
-      const dInfo = durationInfo[r]?.[c] || { duration: 1, rowOffset: 0, isNoteOff: false };
+      const dInfo = durationInfo[r]?.[c] || {
+        duration: 1, rowOffset: 0, isNoteOff: false, isTrigger: false, isSustained: false,
+      };
       cellsWritten++;
 
       let note = 0, inst = 0, volCmd = 0, volVal = 0, effCmd = 0, effVal = 0;
@@ -518,11 +530,11 @@ export const packPatternMatrixHighPrecision = (matrix: PatternMatrix | null, pad
       //   - inst: 8 bits (bit 7 is expression-only flag)
       //   - duration: 8 bits (1-255 rows)
       //   - volPacked: 4 bits volCmd + 4 bits volVal (upper nibbles)
-      // packedB: [effCmd:8][effVal:8][durationFlags:7][reserved:1][volCmd:8]
+      // packedB: [effCmd:8][effVal:8][durationFlags:7][trigger:1][volCmd:8]
       //   - effCmd: 8 bits (effect command)
       //   - effVal: 8 bits (effect value)
       //   - durationFlags: 7 bits [rowOffset:6][isNoteOff:1]
-      //   - reserved: 1 bit
+      //   - trigger: bit 15 — 1.0 on note-on row (TRIG-001)
       //   - volCmd: 8 bits (full volume command for shader)
       
       const duration = Math.min(dInfo.duration, 255);
@@ -540,10 +552,14 @@ export const packPatternMatrixHighPrecision = (matrix: PatternMatrix | null, pad
                            ((duration & 0xFF) << 8) | 
                            (volPacked & 0xFF);
       
-      packedData[offset + 1] = ((effCmd & 0xFF) << 24) | 
-                               ((effVal & 0xFF) << 16) | 
-                               ((durationFlags & 0x7F) << 8) | 
-                               (volCmd & 0xFF);
+      let packedB = ((effCmd & 0xFF) << 24) |
+                    ((effVal & 0xFF) << 16) |
+                    ((durationFlags & 0x7F) << 8) |
+                    (volCmd & 0xFF);
+      if (dInfo.isTrigger && !dInfo.isNoteOff) {
+        packedB |= PACKEDB_TRIGGER_FLAG;
+      }
+      packedData[offset + 1] = packedB;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the hybrid **Trigger + Sustain Tail** visual system: brilliant large nodes on note-on rows, with smaller dimmer trails for held notes. Sustain column data is preserved; rendering branches on an explicit trigger flag.

## Data packing (Part A)

- **TRIG-001**: `packedB` bit 15 (`0x8000`) = explicit note-on trigger flag
- Sustain pitch/instrument data still written down the column (unchanged DURA-001 behavior)
- `calculateNoteDurations()` already computed `isTrigger` — now encoded into GPU buffers
- Helpers: `PACKEDB_TRIGGER_FLAG`, `isTriggerFromPackedB()`
- GPU compute shader (`compute_note_duration.wgsl`) sets trigger bit on note-on rows

### packedB layout (updated)
```
[effCmd:8][effVal:8][durationFlags:7][trigger:1][volCmd:8]
```

## Shader changes (Part B)

| Shader | Changes |
|--------|---------|
| `patternv0.47.wgsl` | Full dual-state rewrite: DURA unpack, trigger (0.45 smoothstep, cyan-blue) vs sustain tail (0.18, desaturated) |
| `patternv0.50/51/55.wgsl` | `isTrigger` in `NoteDurationInfo`, larger trigger lens caps (0.72×0.92) vs sustain (0.44×0.58), intensity split |
| `hooks/webGLShaders.ts` | WebGL2 path mirrors trigger/sustain sizing |

## HTML fallback (Part C)

`PatternSequencer.tsx` uses `calculateNoteDurations()`:
- **Trigger rows**: taller (`scaleY 1.55`), brighter, stronger glow
- **Sustain rows**: shorter (`scaleY 0.75`), desaturated, subtle glow

## Verification criteria addressed

- Short notes → single bright trigger node
- Long notes → bright trigger + continuous dimmer tail
- Different visual weight via cap size + smoothstep radii
- Empty cells remain subtle background
- No full-lane flooding

## Testing

- `npm run typecheck` ✅
- Public shader copies synced
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-733bbff9-9f4d-48a5-89b0-f75699533043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-733bbff9-9f4d-48a5-89b0-f75699533043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

