### PR TITLE
Fix deploy paths, storage API 404 hang, WebGPU WGSL, and native worklet probe

### DIFF
--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -3,9 +3,14 @@ import { LibOpenMPT, ModuleInfo, PatternMatrix, ChannelShadowState, PlaybackStat
 import { OpenMPTWorkletEngine, NATIVE_RING_BUF_BYTES } from '../audio-worklet/OpenMPTWorkletEngine';
 import { computeNoteAges } from '../utils/patternExtractor';
 import { startAudioPlayback, AudioGraphRefs, AudioGraphCallbacks, AudioGraphConfig } from './useAudioGraph';
-import { useWorkletLoader, getWorkletUrl, getNativeGlueUrl, getAbsoluteWorkletUrl } from './useWorkletLoader';
+import {
+  useWorkletLoader,
+  getWorkletUrl,
+  getNativeGlueUrl,
+  getAbsoluteWorkletUrl,
+  withBase,
+} from './useWorkletLoader';
 import { logWorkletDiagnostics } from '../audio-worklet/diagnostics';
-import { withBase } from '../src/lib/paths';
 
 
 // Use Vite BASE_URL for correct resolution under subdirectory deployment

--- a/hooks/useWorkletLoader.ts
+++ b/hooks/useWorkletLoader.ts
@@ -9,7 +9,9 @@
  */
 
 import { useCallback, useRef, useState } from 'react';
-import { detectRuntimeBase } from '../src/lib/paths';
+import { detectRuntimeBase, withBase } from '../src/lib/paths';
+
+export { withBase };
 
 export interface WorkletLoadResult {
   success: boolean;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "sync:shaders": "rsync -av --delete --exclude='legacy/' --exclude='thumbnails/' --exclude='README.md' shaders/ public/shaders/",
+    "sync:shaders": "node scripts/sync-shaders.mjs",
     "predev": "npm run sync:shaders",
     "dev": "vite",
     "prebuild": "npm run sync:shaders",

--- a/scripts/sync-shaders.mjs
+++ b/scripts/sync-shaders.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform shader sync (replaces rsync for CI / minimal environments).
+ * Copies shaders/*.wgsl → public/shaders/, excluding legacy/ and thumbnails/.
+ */
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = 'shaders';
+const DEST = 'public/shaders';
+const SKIP_DIRS = new Set(['legacy', 'thumbnails']);
+const SKIP_FILES = new Set(['README.md']);
+
+function copyDir(src, dest) {
+  mkdirSync(dest, { recursive: true });
+  for (const entry of readdirSync(src)) {
+    if (SKIP_DIRS.has(entry) || SKIP_FILES.has(entry)) continue;
+    const srcPath = join(src, entry);
+    const destPath = join(dest, entry);
+    const st = statSync(srcPath);
+    if (st.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else if (entry.endsWith('.wgsl')) {
+      cpSync(srcPath, destPath);
+    }
+  }
+}
+
+if (!existsSync(SRC)) {
+  console.warn(`[sync-shaders] source dir missing: ${SRC}`);
+  process.exit(0);
+}
+
+if (existsSync(DEST)) {
+  rmSync(DEST, { recursive: true, force: true });
+}
+copyDir(SRC, DEST);
+console.log(`[sync-shaders] synced ${SRC}/ → ${DEST}/`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes production issues on `test.1ink.us/xm-player/`:

### Storage API (UI hang / wrong formatting)
- **`utils/storageApi.ts`**: API URLs now use `detectRuntimeBase()` → `/xm-player/api/songs` not `/api/songs`
- **Graceful degradation**: `fetchRemoteSongs()` / `fetchShaders()` return `[]` on 404, network errors, or invalid JSON (no React Query error state)
- **`hooks/useLibrary.ts`**: `retry: false` to avoid retry storms

### Base path detection
- **`src/lib/paths.ts`**: `/xm-player` (no trailing slash) now resolves to `/xm-player/`

### WebGPU (from TRIG-001)
- **`compute_note_duration.wgsl`**: `isNoteOffFlag == 0u` instead of `!isNoteOffFlag` (u32)

### Native audio engine probe
- **`isNativeGlueAvailable()`**: fetches script text and skips `import()` if it registers `AudioWorkletProcessor` on main thread
- Prevents `ReferenceError: AudioWorkletProcessor is not defined` during init

### Deploy / build
- `npm run build:xm-player` for correct asset paths
- `deploy.py` validates subdirectory base before upload
- `scripts/sync-shaders.mjs` replaces rsync

## Redeploy

```bash
npm run build:xm-player
python3 deploy.py
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-733bbff9-9f4d-48a5-89b0-f75699533043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-733bbff9-9f4d-48a5-89b0-f75699533043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

