### PR TITLE
Fix WebGPU compute shader WGSL error and xm-player deploy base path

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -99,14 +99,32 @@ def deploy_bundle(build_path: Path) -> bool:
         return False
 
 
+def validate_build_base_path(build_path: Path) -> None:
+    """Warn when dist was built without the /xm-player/ base path (breaks CSS/JS on deploy)."""
+    index_html = build_path / "index.html"
+    if not index_html.is_file():
+        return
+    html = index_html.read_text(encoding="utf-8")
+    expected_prefix = f"/{PROJECT_NAME}/"
+    if expected_prefix not in html and 'src="/assets/' in html:
+        print(
+            f"ERROR: {index_html} was built with base '/' but deploy target is '{expected_prefix}'.\n"
+            f"       CSS and layout will break on test.1ink.us/xm-player/.\n"
+            f"       Rebuild with:  npm run build:xm-player"
+        )
+        sys.exit(1)
+
+
 def main():
     print(f"\n=== Deploying '{PROJECT_NAME}' via Contabo -> test.1ink.us/xm-player ===\n")
 
     build_path = Path(BUILD_DIR)
     if not build_path.exists() or not build_path.is_dir():
         print(f"ERROR: Build directory '{BUILD_DIR}/' does not exist.")
-        print("Run:  VITE_APP_BASE_PATH=/xm-player/ npm run build")
+        print("Run:  npm run build:xm-player")
         sys.exit(1)
+
+    validate_build_base_path(build_path)
 
     try:
         health = requests.get(f"{CONTABO_BASE_URL}/api/deploy/health", timeout=10)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:worklet": "bash ./build-wasm.sh",
     "build:emcc": "bash scripts/build-wasm.sh",
     "build": "tsc && node --max-old-space-size=4096 node_modules/.bin/vite build",
+    "build:xm-player": "VITE_APP_BASE_PATH=/xm-player/ npm run build",
     "preview": "vite preview",
     "lint": "exit 0",
     "typecheck": "tsc --noEmit",

--- a/public/shaders/compute_note_duration.wgsl
+++ b/public/shaders/compute_note_duration.wgsl
@@ -217,8 +217,8 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
                    ((outEffVal & 0xFFu) << 16u) |
                    ((durationFlags & 0x7Fu) << 8u) |
                    (outVolCmd & 0xFFu);
-        // TRIG-001: explicit trigger flag on note-on rows
-        if (rowOffset == 0u && !isNoteOffFlag) {
+        // TRIG-001: explicit trigger flag on note-on rows (isNoteOffFlag is u32, not bool)
+        if (rowOffset == 0u && isNoteOffFlag == 0u) {
             outB = outB | 0x8000u;
         }
 

--- a/shaders/compute_note_duration.wgsl
+++ b/shaders/compute_note_duration.wgsl
@@ -217,8 +217,8 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
                    ((outEffVal & 0xFFu) << 16u) |
                    ((durationFlags & 0x7Fu) << 8u) |
                    (outVolCmd & 0xFFu);
-        // TRIG-001: explicit trigger flag on note-on rows
-        if (rowOffset == 0u && !isNoteOffFlag) {
+        // TRIG-001: explicit trigger flag on note-on rows (isNoteOffFlag is u32, not bool)
+        if (rowOffset == 0u && isNoteOffFlag == 0u) {
             outB = outB | 0x8000u;
         }
 


### PR DESCRIPTION
- compute_note_duration.wgsl: compare isNoteOffFlag as u32 (== 0u), not !bool Fixes WGSL parse error that broke WebGPU init after TRIG-001
- Add npm run build:xm-player for correct /xm-player/ asset paths
- deploy.py validates dist was built with subdirectory base (prevents CSS/layout break)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability in rendering calculations through type-correct shader operations
  * Added validation to prevent deployment misconfigurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->