### PR TITLE
Fix WebGL2 hybrid overlay placement vs WGSL shaders

### DIFF
--- a/components/PatternDisplay.tsx
+++ b/components/PatternDisplay.tsx
@@ -635,7 +635,10 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
           {...(onSeek ? { onSeek } : {})}
         />
       ) : (
-        <>
+        <div
+          className="relative max-w-full max-h-full"
+          style={{ width: 'fit-content', height: 'fit-content' }}
+        >
           <canvas
             ref={canvasRef}
             data-shader-preview-source="true"
@@ -643,17 +646,17 @@ export const PatternDisplay: React.FC<PatternDisplayProps> = ({
             width={canvasMetrics.width}
             height={canvasMetrics.height}
             onClick={handleCanvasClick}
-            className={`${padTopChannel && !shaderFile.includes('v0.40') && !shaderFile.includes('v0.43') && !shaderFile.includes('v0.44') ? 'rounded bg-black shadow-inner border border-black/50' : ''} cursor-pointer`}
-            style={{ width: 'auto', height: 'auto', maxWidth: '100%', maxHeight: '100%', aspectRatio: `${canvasMetrics.width} / ${canvasMetrics.height}`, objectFit: 'contain', position: 'relative' }}
+            className={`${padTopChannel && !shaderFile.includes('v0.40') && !shaderFile.includes('v0.43') && !shaderFile.includes('v0.44') ? 'rounded bg-black shadow-inner border border-black/50' : ''} cursor-pointer block`}
+            style={{ width: 'auto', height: 'auto', maxWidth: '100%', maxHeight: '100%', aspectRatio: `${canvasMetrics.width} / ${canvasMetrics.height}`, objectFit: 'contain' }}
           />
           <canvas
             ref={glCanvasRef}
             width={canvasMetrics.width}
             height={canvasMetrics.height}
-            className="absolute top-0 left-0 pointer-events-none"
-            style={{ width: 'auto', height: 'auto', maxWidth: '100%', maxHeight: '100%', aspectRatio: `${canvasMetrics.width} / ${canvasMetrics.height}`, objectFit: 'contain', zIndex: 2, position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', display: isOverlayActive ? 'block' : 'none' }}
+            className="absolute inset-0 pointer-events-none"
+            style={{ display: isOverlayActive ? 'block' : 'none', zIndex: 2, width: '100%', height: '100%' }}
           />
-        </>
+        </div>
       )}
 
       {!useHTML && useWebGPU && !webgpuAvailable && (

--- a/hooks/useWebGLOverlay.ts
+++ b/hooks/useWebGLOverlay.ts
@@ -17,6 +17,7 @@ import {
   calculateHorizontalCellSize,
   calculateCapScale,
   getLayoutModeFromShader,
+  horizontalLayoutHasHeader,
   LAYOUT_MODES,
 } from '../utils/geometryConstants';
 import { detectRuntimeBase } from '../src/lib/paths';
@@ -471,10 +472,11 @@ export function useWebGLOverlay(
         layoutMode = p.stepsLength === 64 ? LAYOUT_MODES.HORIZONTAL_64 : LAYOUT_MODES.HORIZONTAL_32;
       }
       const channelCount = cols;
+      const hasHeaderRow = p.padTopChannel && horizontalLayoutHasHeader(channelCount);
 
       if (layoutMode === LAYOUT_MODES.HORIZONTAL_32) {
         {
-          const metrics = calculateHorizontalCellSize(gl.canvas.width, gl.canvas.height, 32, channelCount);
+          const metrics = calculateHorizontalCellSize(gl.canvas.width, gl.canvas.height, 32, channelCount, hasHeaderRow);
           effectiveCellW = metrics.cellW;
           effectiveCellH = metrics.cellH;
           offsetX = metrics.offsetX;
@@ -483,7 +485,7 @@ export function useWebGLOverlay(
         }
         if (uniforms.u_offset != null) gl.uniform2f(uniforms.u_offset, offsetX, offsetY);
       } else if (layoutMode === LAYOUT_MODES.HORIZONTAL_64) {
-        const metrics = calculateHorizontalCellSize(gl.canvas.width, gl.canvas.height, 64, channelCount);
+        const metrics = calculateHorizontalCellSize(gl.canvas.width, gl.canvas.height, 64, channelCount, hasHeaderRow);
         effectiveCellW = metrics.cellW;
         effectiveCellH = metrics.cellH;
         offsetX = metrics.offsetX;
@@ -513,7 +515,7 @@ export function useWebGLOverlay(
       gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
 
       const stepsForMode = layoutMode === LAYOUT_MODES.HORIZONTAL_32 ? 32 :
-        layoutMode === LAYOUT_MODES.HORIZONTAL_64 ? 64 : 64;
+        layoutMode === LAYOUT_MODES.HORIZONTAL_64 ? 64 : rows;
       const totalInstances = stepsForMode * cols;
 
       uniformVals['totalInstances'] = totalInstances;

--- a/hooks/webGLShaders.ts
+++ b/hooks/webGLShaders.ts
@@ -140,8 +140,16 @@ export function buildVertexShader(useNoteSustainTailMode: boolean, isV021: boole
             if (v_hasNote < 0.5) capScale = 0.0;
             capScale *= 1.0 + (0.2 * activation);
 
-            float cellX = u_offset.x + float(stepIndex)  * u_cellSize.x;
-            float cellY = u_offset.y + float(trackIndex) * u_cellSize.y;
+            // Mirror patternv0.40.wgsl header-row channelIndex remapping.
+            bool hasHeader = u_cols > 1.0 && (u_offset.y / u_resolution.y) > 0.14;
+            float dataChannels = u_cols - (hasHeader ? 1.0 : 0.0);
+            float effectiveChannel = float(trackIndex);
+            float channelIndex = (hasHeader && effectiveChannel > 0.0)
+                ? effectiveChannel - 1.0
+                : effectiveChannel;
+
+            float cellX = u_offset.x + float(stepIndex) * u_cellSize.x;
+            float cellY = u_offset.y + (channelIndex / max(1.0, dataChannels)) * (dataChannels * u_cellSize.y);
 
             vec2 centered = a_pos * capScale + vec2(cellX + u_cellSize.x * 0.5, cellY + u_cellSize.y * 0.5);
             vec2 ndc = (centered / u_resolution) * 2.0 - 1.0;
@@ -162,7 +170,7 @@ export function buildVertexShader(useNoteSustainTailMode: boolean, isV021: boole
             // Match WGSL: cell center is at ring-start, not ring-center
             float pixelRadius = minRadius + trackIndexF * ringDepth;
 
-            float totalSteps = 64.0;
+            float totalSteps = max(u_rows, 1.0);
             float anglePerStep = (2.0 * PI) / totalSteps;
             float theta = -1.570796 + float(stepIndex) * anglePerStep;
 

--- a/src/renderers/webgl2/WebGL2PatternRenderer.ts
+++ b/src/renderers/webgl2/WebGL2PatternRenderer.ts
@@ -7,6 +7,7 @@ import {
   calculateHorizontalCellSize,
   calculateCapScale,
   getLayoutModeFromShader,
+  horizontalLayoutHasHeader,
   LAYOUT_MODES,
 } from '../../../utils/geometryConstants';
 import { getShaderMeta } from '../../../utils/shaderRegistry';
@@ -358,15 +359,16 @@ export class WebGL2PatternRenderer {
     let effectiveCellH = params.cellHeight;
     let offsetX = 0;
     let offsetY = 0;
+    const hasHeaderRow = padTopChannel && horizontalLayoutHasHeader(cols);
 
     if (layoutMode === LAYOUT_MODES.HORIZONTAL_32) {
-      const m = calculateHorizontalCellSize(canvas.width, canvas.height, 32, cols);
+      const m = calculateHorizontalCellSize(canvas.width, canvas.height, 32, cols, hasHeaderRow);
       effectiveCellW = m.cellW;
       effectiveCellH = m.cellH;
       offsetX = m.offsetX;
       offsetY = m.offsetY;
     } else if (layoutMode === LAYOUT_MODES.HORIZONTAL_64) {
-      const m = calculateHorizontalCellSize(canvas.width, canvas.height, 64, cols);
+      const m = calculateHorizontalCellSize(canvas.width, canvas.height, 64, cols, hasHeaderRow);
       effectiveCellW = m.cellW;
       effectiveCellH = m.cellH;
       offsetX = m.offsetX;
@@ -411,7 +413,7 @@ export class WebGL2PatternRenderer {
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
 
     const stepsForMode = layoutMode === LAYOUT_MODES.HORIZONTAL_32 ? 32
-      : layoutMode === LAYOUT_MODES.HORIZONTAL_64 ? 64 : 64;
+      : layoutMode === LAYOUT_MODES.HORIZONTAL_64 ? 64 : rows;
     const totalInstances = stepsForMode * cols;
     uniformVals['totalInstances'] = totalInstances;
     uniformVals['layoutMode'] = layoutModeName;

--- a/utils/geometryConstants.ts
+++ b/utils/geometryConstants.ts
@@ -32,23 +32,41 @@ export const LAYOUT_MODES = {
 
 export type LayoutMode = typeof LAYOUT_MODES[keyof typeof LAYOUT_MODES];
 
-// Calculate horizontal cell size based on canvas dimensions
+export type HorizontalCellMetrics = {
+  cellW: number;
+  cellH: number;
+  offsetX: number;
+  offsetY: number;
+  /** Channels that carry pattern data (excludes optional header/pad row). */
+  dataChannels: number;
+};
+
+// Calculate horizontal cell size based on canvas dimensions.
+// When hasHeaderRow is true (padTopChannel), row height matches WGSL gridRect math:
+// data rows divide gridRect.h by dataChannels, not the padded channel count.
 export function calculateHorizontalCellSize(
   canvasWidth: number,
   canvasHeight: number,
   steps: number,
-  numChannels: number
-): { cellW: number; cellH: number; offsetX: number; offsetY: number } {
+  numChannels: number,
+  hasHeaderRow = false,
+): HorizontalCellMetrics {
   const gridW = canvasWidth * GRID_RECT.w;
   const gridH = canvasHeight * GRID_RECT.h;
-  
+
+  const dataChannels = hasHeaderRow ? Math.max(1, numChannels - 1) : numChannels;
   const cellW = gridW / steps;
-  const cellH = gridH / numChannels;
-  
+  const cellH = gridH / dataChannels;
+
   const offsetX = canvasWidth * GRID_RECT.x;
   const offsetY = canvasHeight * GRID_RECT.y;
-  
-  return { cellW, cellH, offsetX, offsetY };
+
+  return { cellW, cellH, offsetX, offsetY, dataChannels };
+}
+
+/** True when WGSL horizontal shaders reserve channel 0 as a header/pad row. */
+export function horizontalLayoutHasHeader(numChannels: number): boolean {
+  return numChannels > 1 && GRID_RECT.y > 0.15;
 }
 
 // Calculate cap scale for pixel-perfect button sizing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Headless Colab screenshots showed WebGPU unavailable (expected) and highlighted that the WebGL frosted-cap overlay can drift from the WGSL cell grid. This PR aligns overlay geometry with the WGSL shaders in three areas.

## Findings from Colab / headless captures

- **WebGPU path** (`?renderer=webgpu`): canvas stays blank in headless Chrome — overlay cannot be visually verified there, but console/packing paths are clean.
- **WebGL2 path** (`?renderer=webgl2`): falls back to HTML in headless Puppeteer (no WebGL2 context), so shader captures are the DOM grid — not the GPU overlay stack.
- **Hybrid path** (WebGPU + `useWebGLOverlay`): the real misalignment bug lives here when both layers render.

## Root causes fixed

1. **Canvas stacking** — The overlay canvas was absolutely centered in the flex container (`top/left 50% + translate`), while the WebGPU canvas was centered as a flex child. Sub-pixel drift between the two centering strategies caused visible cap offset.
2. **Circular step count** — Overlay GLSL hardcoded `totalSteps = 64.0`; WGSL shaders use `uniforms.numRows` for arc spacing (v0.42, v0.45b, v0.46, etc.).
3. **Horizontal header row** — `patternv0.40.wgsl` remaps channel 0 as a header/pad row and divides `gridRect.h` by `dataChannels` (not padded channel count). The overlay used raw `trackIndex * cellH` with `cellH = gridH / numChannels`, shifting data rows down one line.

## Changes

- `components/PatternDisplay.tsx` — wrap WebGPU + overlay canvases in a shared `relative` container; overlay uses `inset-0` on that wrapper.
- `hooks/webGLShaders.ts` — circular `totalSteps` from `u_rows`; horizontal Y uses WGSL `channelIndex` remapping.
- `utils/geometryConstants.ts` — `calculateHorizontalCellSize(..., hasHeaderRow)` + `horizontalLayoutHasHeader()` helper.
- `hooks/useWebGLOverlay.ts` + `WebGL2PatternRenderer.ts` — pass header-row flag; circular instance count uses `rows`.

## Verification

- `npm run typecheck` ✅
- `npm run build` ✅

## Manual follow-up

In a WebGPU-capable browser, load a hybrid shader (`patternv0.46.wgsl`, `patternv0.45b.wgsl`, or `patternv0.40.wgsl`) and confirm frosted caps sit on the WGSL cell centers while seeking rows 0/16/32.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-322c8371-bfde-45e2-a7a4-761e4aafd5b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-322c8371-bfde-45e2-a7a4-761e4aafd5b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

