### PR TITLE
Fix WebGL overlay placement and octave note-color parity

### DIFF
--- a/hooks/useWebGLOverlay.ts
+++ b/hooks/useWebGLOverlay.ts
@@ -17,8 +17,10 @@ import {
   calculateHorizontalCellSize,
   calculateCapScale,
   getLayoutModeFromShader,
+  getPolarRadii,
   horizontalLayoutHasHeader,
   LAYOUT_MODES,
+  usesCircularRowPaging,
 } from '../utils/geometryConstants';
 import { detectRuntimeBase } from '../src/lib/paths';
 
@@ -80,6 +82,7 @@ export function useWebGLOverlay(
     }
     const useNoteSustainTailMode = shaderFile.includes('v0.45b');
     const isV021 = shaderFile.includes('v0.21');
+    const useCircularPaging = usesCircularRowPaging(shaderFile);
     console.group('🔧 initWebGL');
 
     // Clean up existing WebGL resources first
@@ -128,7 +131,7 @@ export function useWebGLOverlay(
     // --- VERTEX SHADER ---
     // Fetches cell data (packedA, packedB) and channel state in the VS,
     // passes as flat varyings to avoid per-pixel texelFetch.
-    const vsSource = buildVertexShader(useNoteSustainTailMode, isV021);
+    const vsSource = buildVertexShader(useNoteSustainTailMode, isV021, useCircularPaging);
 
     // Only compile if using a hybrid shader that needs WebGL caps
     if (!WEBGL_HYBRID_SHADERS.has(shaderFile)) {
@@ -426,10 +429,8 @@ export function useWebGLOverlay(
         setUniform('u_bloomIntensity', uniforms.u_bloomIntensity, gl.uniform1f.bind(gl), p.bloomIntensity ?? 1.0);
         setUniform('u_timeSec', uniforms.u_timeSec, gl.uniform1f.bind(gl), performance.now() / 1000.0);
 
-        // Dynamic radius uniforms — mirror WebGPU shader values
-        const minDim = Math.min(gl.canvas.width, gl.canvas.height);
-        const innerRadius = minDim * 0.15;
-        const outerRadius = minDim * 0.45;
+        // Dynamic radius uniforms — shared with WebGPU via getPolarRadii()
+        const { innerRadius, outerRadius } = getPolarRadii(gl.canvas.width, gl.canvas.height, p.shaderFile);
         setUniform('u_innerRadius', uniforms.u_innerRadius, gl.uniform1f.bind(gl), innerRadius);
         setUniform('u_outerRadius', uniforms.u_outerRadius, gl.uniform1f.bind(gl), outerRadius);
         uniformVals['u_innerRadius'] = innerRadius.toFixed(2);

--- a/hooks/useWebGPURender.ts
+++ b/hooks/useWebGPURender.ts
@@ -36,7 +36,7 @@ import {
   type NoteDurationComputeState,
 } from '../utils/computeNoteDuration';
 import type { BloomPostProcessor } from '../utils/bloomPostProcessor';
-import { GRID_RECT } from '../utils/geometryConstants';
+import { GRID_RECT, getPolarRadii } from '../utils/geometryConstants';
 import { withBase } from '../src/lib/paths';
 import { generateEmptyInstrumentPalette, MAX_INSTRUMENT_PALETTE_SIZE } from '../utils/instrumentPalette';
 
@@ -706,11 +706,7 @@ export function useWebGPURender(
         effectiveCellH = actualCanvasH / numChannels;
       }
 
-      const minDim = Math.min(actualCanvasW, actualCanvasH);
-      const innerRadius = minDim * 0.15;
-      // v0.45 (non-b) intentionally shrinks to 0.40 to make room for buttons;
-      // all other circular shaders (including v0.45b) use 0.45 to align with the WebGL2 overlay.
-      const outerRadius = (shaderFile.includes('v0.45') && !shaderFile.includes('v0.45b')) ? minDim * 0.40 : minDim * 0.45;
+      const { innerRadius, outerRadius } = getPolarRadii(actualCanvasW, actualCanvasH, shaderFile);
 
       const uniformByteLength = fillUniformPayload(layoutTypeRef.current, {
         numRows: visibleRows, numChannels,

--- a/hooks/webGLShaders.ts
+++ b/hooks/webGLShaders.ts
@@ -1,7 +1,11 @@
 // WebGL2 GLSL shader source builders for the WebGL overlay subsystem.
 // Parameterized by two runtime booleans that get baked into GLSL constants.
 
-export function buildVertexShader(useNoteSustainTailMode: boolean, isV021: boolean): string {
+export function buildVertexShader(
+  useNoteSustainTailMode: boolean,
+  isV021: boolean,
+  useCircularPaging = false,
+): string {
   return `#version 300 es
     precision highp float;
     precision highp int;
@@ -41,6 +45,7 @@ export function buildVertexShader(useNoteSustainTailMode: boolean, isV021: boole
     const uint NOTE_FADE = 99u;  // Note-fade command
     const bool USE_NOTE_SUSTAIN_TAIL_MODE = ${useNoteSustainTailMode ? 'true' : 'false'};
     const bool IS_V021 = ${isV021 ? 'true' : 'false'};
+    const bool USE_CIRCULAR_PAGING = ${useCircularPaging ? 'true' : 'false'};
 
     void main() {
         int id = gl_InstanceID;
@@ -48,12 +53,14 @@ export function buildVertexShader(useNoteSustainTailMode: boolean, isV021: boole
         int stepIndex  = id / int(u_cols);
 
         // Page-aware cell data fetch.
-        // Horizontal layouts page through the pattern (32 or 64 steps per page);
-        // circular layouts show all rows directly but must clamp to valid range.
+        // Horizontal: page by 32/64 steps. Circular (v0.46): page by numRows.
         int actualRow;
         if (u_layoutMode == 2 || u_layoutMode == 3) {
             float stepsPerPageH = (u_layoutMode == 3) ? 64.0 : 32.0;
             int pageStart = int(floor(u_playhead / stepsPerPageH) * stepsPerPageH);
+            actualRow = clamp(pageStart + stepIndex, 0, int(u_rows) - 1);
+        } else if (USE_CIRCULAR_PAGING) {
+            int pageStart = int(floor(u_playhead / u_rows) * u_rows);
             actualRow = clamp(pageStart + stepIndex, 0, int(u_rows) - 1);
         } else {
             actualRow = clamp(stepIndex, 0, int(u_rows) - 1);
@@ -172,7 +179,9 @@ export function buildVertexShader(useNoteSustainTailMode: boolean, isV021: boole
 
             float totalSteps = max(u_rows, 1.0);
             float anglePerStep = (2.0 * PI) / totalSteps;
-            float theta = -1.570796 + float(stepIndex) * anglePerStep;
+            // Match WGSL: angular slot uses row % numRows (within a page, == stepIndex)
+            int angleRow = USE_CIRCULAR_PAGING ? (actualRow % int(u_rows)) : stepIndex;
+            float theta = -1.570796 + float(angleRow) * anglePerStep;
 
             float circumference = 2.0 * PI * pixelRadius;
             float arcLength = circumference / totalSteps;
@@ -260,6 +269,13 @@ export function buildFragmentShader(useNoteSustainTailMode: boolean, isV021: boo
         if (note < 1u || note > 96u) return 0.0;
         uint semi = (note - 1u) % 12u;
         return float(semi) / 12.0;
+    }
+
+    // Octave brightness: same pitch class across octaves, brighter in higher octaves (v0.50 parity)
+    float octaveBrightness(uint note) {
+        if (note < 1u || note > 96u) return 1.0;
+        uint oct = (note - 1u) / 12u;
+        return 0.65 + 0.35 * float(oct) / 9.0;
     }
 
     // --- SDF: Rounded Box ---
@@ -464,7 +480,7 @@ export function buildFragmentShader(useNoteSustainTailMode: boolean, isV021: boo
                     // Bright Blue/Cyan glow for active note
                     topIntensity = 3.0;
                     float pitchHue = pitchClassFromIndex(note);
-                    midColor = neonPalette(pitchHue);
+                    midColor = neonPalette(pitchHue) * octaveBrightness(note);
                     midIntensity = 0.6 + bloom * 2.0;
                     botIntensity = 0.6;
                 } else if (v_active > 0.5) {
@@ -503,7 +519,7 @@ export function buildFragmentShader(useNoteSustainTailMode: boolean, isV021: boo
             midIntensity = 0.12;
             if (hasNote && !isExpressionOnly) {
                 float pitchHue = pitchClassFromIndex(note);
-                vec3 pitchColor = neonPalette(pitchHue);
+                vec3 pitchColor = neonPalette(pitchHue) * octaveBrightness(note);
                 float dist = length(lensUV);
                 if (is_trigger) {
                     // TRIGGER NODE: large, brilliant, bloom halo
@@ -515,7 +531,7 @@ export function buildFragmentShader(useNoteSustainTailMode: boolean, isV021: boo
                         midIntensity = max(midIntensity, 0.8 + v_active * (1.0 + bloom));
                     }
                 } else if (isSustaining && !USE_NOTE_SUSTAIN_TAIL_MODE) {
-                    // SUSTAIN TAIL: smaller, thinner, darker
+                    // SUSTAIN TAIL: smaller, thinner, darker — pitch hue preserved, dimmed
                     float tailIntensity = smoothstep(0.16, 0.0, dist) * 0.60;
                     float fade = 1.0 - sustainProgress * 0.35;
                     noteColor = mix(tailCol, pitchColor * 0.45, 0.25);

--- a/src/renderers/webgl2/WebGL2PatternRenderer.ts
+++ b/src/renderers/webgl2/WebGL2PatternRenderer.ts
@@ -7,8 +7,10 @@ import {
   calculateHorizontalCellSize,
   calculateCapScale,
   getLayoutModeFromShader,
+  getPolarRadii,
   horizontalLayoutHasHeader,
   LAYOUT_MODES,
+  usesCircularRowPaging,
 } from '../../../utils/geometryConstants';
 import { getShaderMeta } from '../../../utils/shaderRegistry';
 import { detectRuntimeBase } from '../../../src/lib/paths';
@@ -126,7 +128,8 @@ export class WebGL2PatternRenderer {
   private initPattern(gl: WebGL2RenderingContext, shaderFile: string): void {
     const useNoteSustainTailMode = shaderFile.includes('v0.45b'); // TRIG-001: strict playhead sustain (v0.45b only)
     const isV021 = shaderFile.includes('v0.21');
-    const vsSource = buildVertexShader(useNoteSustainTailMode, isV021);
+    const useCircularPaging = usesCircularRowPaging(shaderFile);
+    const vsSource = buildVertexShader(useNoteSustainTailMode, isV021, useCircularPaging);
     const fsSource = buildPatternFragmentShader(useNoteSustainTailMode, isV021);
 
     const vs = compileShader(gl, gl.VERTEX_SHADER, vsSource, 'pattern-vs');
@@ -259,7 +262,6 @@ export class WebGL2PatternRenderer {
   ): void {
     const chassis = this.chassis!;
     const canvas = this.canvas!;
-    const minDim = Math.min(canvas.width, canvas.height);
 
     gl.useProgram(chassis.program);
     gl.bindVertexArray(this.chassisVao);
@@ -283,8 +285,9 @@ export class WebGL2PatternRenderer {
     setF('u_filmGrain', params.filmGrain ?? 0);
     setF('u_invertMix', params.invertMix ?? 0);
     setI('u_nightPreset', params.nightPreset ?? 0);
-    setF('u_innerRadius', minDim * 0.15);
-    setF('u_outerRadius', minDim * 0.45);
+    const { innerRadius, outerRadius } = getPolarRadii(canvas.width, canvas.height, this.shaderFile);
+    setF('u_innerRadius', innerRadius);
+    setF('u_outerRadius', outerRadius);
     setI('u_layoutMode', layoutMode === LAYOUT_MODES.CIRCULAR ? 1 : 0);
 
     uniformVals['chassis_themeBlend'] = (params.themeBlend ?? 0).toFixed(2);
@@ -375,9 +378,7 @@ export class WebGL2PatternRenderer {
       offsetY = m.offsetY;
     }
 
-    const minDim = Math.min(canvas.width, canvas.height);
-    const innerRadius = minDim * 0.15;
-    const outerRadius = minDim * 0.45;
+    const { innerRadius, outerRadius } = getPolarRadii(canvas.width, canvas.height, this.shaderFile);
 
     const u = res.uniforms;
     if (u.u_resolution) gl.uniform2f(u.u_resolution, canvas.width, canvas.height);

--- a/utils/geometryConstants.ts
+++ b/utils/geometryConstants.ts
@@ -12,11 +12,33 @@ export const GRID_RECT = {
   h: 0.7    // Height
 };
 
-// Polar ring dimensions for circular layouts
+// Polar ring dimensions for circular layouts (normalized 0–1 factors of minDim)
 export const POLAR_RINGS = {
-  INNER_RADIUS: 0.3,
-  OUTER_RADIUS: 0.9
+  INNER_RADIUS: 0.15,
+  OUTER_RADIUS: 0.45,
+  /** v0.45 (non-b) shrinks outer ring to make room for embedded UI controls */
+  OUTER_RADIUS_V045: 0.40,
 };
+
+/** Pixel inner/outer radii for circular shaders — keep WebGPU + WebGL overlay in sync. */
+export function getPolarRadii(
+  canvasWidth: number,
+  canvasHeight: number,
+  shaderFile: string,
+): { innerRadius: number; outerRadius: number } {
+  const minDim = Math.min(canvasWidth, canvasHeight);
+  const innerRadius = minDim * POLAR_RINGS.INNER_RADIUS;
+  const outerFactor =
+    shaderFile.includes('v0.45') && !shaderFile.includes('v0.45b')
+      ? POLAR_RINGS.OUTER_RADIUS_V045
+      : POLAR_RINGS.OUTER_RADIUS;
+  return { innerRadius, outerRadius: minDim * outerFactor };
+}
+
+/** Circular shaders that page rows by numRows (e.g. v0.46) — WebGL overlay must match. */
+export function usesCircularRowPaging(shaderFile: string): boolean {
+  return shaderFile.includes('v0.46');
+}
 
 // Cap/button configuration
 export const CAP_CONFIG = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited shader pattern playback accuracy against `docs/planning/trigger-sustain-tails.md` and the v0.50 WGSL reference. Data packing (TRIG-001 / DURA-001) is correct — `npm run test:trigger-tail` and `npm run test:duration-parity` both pass. The main gaps were in the **WebGL2 hybrid overlay** layer that composites frosted LED caps on top of WebGPU shaders.

## Problems found

### 1. WebGL overlay misplacement (circular / v0.46)
Hybrid overlay vertex shader always fetched pattern data from absolute rows `0..numRows-1`. WGSL `patternv0.46.wgsl` pages by `floor(playhead / numRows) * numRows`, so once playback passed row 64 the overlay showed the wrong pattern slice while WebGPU showed the current page.

### 2. Inconsistent polar radii
`useWebGLOverlay` hard-coded `outerRadius = minDim * 0.45` for all shaders. WebGPU uses `0.40` for `v0.45` (non-b) to leave room for embedded UI — overlay caps were drawn outside the WGSL ring grid.

### 3. Missing octave brightness in WebGL overlay
WGSL v0.50+ uses `octaveBrightness(note)` so the same pitch class shares hue across octaves but gets brighter in higher octaves (`0.65` at C-0 → `1.0` at B-9). The WebGL overlay only used `pitchClassFromIndex` — C-3 and C-5 looked identical.

### 4. Trigger + sustain tail behavior (already correct in data layer)
Per `trigger-sustain-tails.md`:
- **Trigger row**: brilliant large node, blue top emitter flash, pitch-colored mid emitter
- **Sustain tail rows**: smaller dim cap, pitch hue at ~45% brightness, no lane flooding

Packing sets `PACKEDB_TRIGGER_FLAG` on note-on rows and copies pitch onto tail rows (DURA-003). WebGL fragment shader already branches `is_trigger` vs `isSustaining` — the overlay was drawing the right *states* but wrong *positions* and *colors*.

## Fixes in this PR

- `utils/geometryConstants.ts`: `getPolarRadii()` + `usesCircularRowPaging()` — single source for WebGPU/WebGL radii
- `hooks/webGLShaders.ts`: circular paging for v0.46; `octaveBrightness()` in fragment shader
- `hooks/useWebGLOverlay.ts` + `WebGL2PatternRenderer.ts`: consume shared helpers

## Still recommended (follow-up)

| Area | Status | Notes |
|------|--------|-------|
| WGSL v0.46/v0.47/v0.48 octave brightness | Missing | v0.50+ has it; older LED shaders still pitch-class only |
| Playhead timing drift (Worklet) | Open | See `docs/planning/accurate_playback.md` — ~200ms lag vs ScriptProcessor |
| v0.50 default has no WebGL hybrid | By design | Overlay only on `webglHybrid: true` shaders (v0.38, v0.40, v0.45b, v0.46, …) |
| Visual regression screenshots | Manual | `npm run capture:trigger-tail` against preview server |

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:trigger-tail`
- [x] `npm run test:duration-parity`
- [ ] Visual: load a module on `patternv0.46.wgsl`, seek past row 64 — overlay caps should track the paged grid
- [ ] Visual: compare C-3 vs C-5 notes on hybrid shader — mid emitter should be same hue, different brightness
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51c68a75-7937-4d6d-af4f-41177bf00626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51c68a75-7937-4d6d-af4f-41177bf00626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for circular row paging for compatible shader versions.

* **Improvements**
  * Refactored polar radius computation for improved rendering accuracy based on shader configuration.
  * Enhanced visual rendering with octave brightness adjustments for better color representation across different note ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->