### PR TITLE
docs: add GitHub issue drafts for page-load & renderer failures (#273–#277)

### DIFF
--- a/.github/issues/issue-1-webgpu-fallback.md
+++ b/.github/issues/issue-1-webgpu-fallback.md
@@ -1,0 +1,157 @@
+## Summary
+
+On production (`https://test.1ink.us/xm-player/`), browsers that expose `navigator.gpu` but cannot obtain a usable GPU adapter (or fail during WebGPU device/pipeline init) get a hard error overlay instead of automatically falling back to WebGL2 or the HTML renderer.
+
+**Impact:** Users on Safari, GPU-disabled environments, and some Linux/VM setups see a non-functional visualization unless they manually add `?renderer=webgl2` or `?renderer=html`.
+
+**Investigation date:** 2026-06-17
+
+---
+
+## Current Behavior
+
+1. Renderer selection runs synchronously at mount and picks `webgpu` when `navigator.gpu` exists.
+2. WebGPU initialization runs asynchronously in `useWebGPURender` and may fail later (null adapter, `requestDevice` failure, shader/pipeline error).
+3. On failure, `setWebgpuAvailable(false)` is called, but `activeBackend` remains `'webgpu'`.
+4. `PatternDisplay` renders a blocking error overlay:
+
+> WebGPU not available — use `?renderer=webgl2` or `?renderer=html`
+
+Manual `?renderer=webgl2` works around the problem.
+
+---
+
+## Root Cause
+
+Renderer availability is checked in two disconnected places with different rigor:
+
+### 1. Sync capability probe is too weak
+
+`src/renderers/rendererSelection.ts`:
+
+```ts
+export function isWebGPUAvailable(): boolean {
+  return typeof navigator !== 'undefined' && 'gpu' in navigator;
+}
+```
+
+This returns `true` whenever the WebGPU API object exists, **without** calling `navigator.gpu.requestAdapter()`. Many environments expose the API but return `null` from `requestAdapter()` (no suitable GPU, blocked adapter, software-only path rejected, etc.).
+
+`resolvePatternRenderer()` uses this probe for the default path:
+
+```ts
+if (isWebGPUAvailable()) return 'webgpu';
+if (isWebGL2Available()) return 'webgl2';
+return 'html';
+```
+
+### 2. Init-time failure does not re-resolve backend
+
+`hooks/useWebGPURender.ts` correctly probes the adapter at init:
+
+```ts
+const adapter = await navigator.gpu.requestAdapter();
+if (!adapter || cancelled) { setWebgpuAvailable(false); return; }
+// ...
+} catch (error) {
+  console.error('Failed to initialize WebGPU pattern display', error);
+  if (!cancelled) setWebgpuAvailable(false);
+}
+```
+
+But this only flips a boolean — it never calls `setRendererOverride('webgl2')` or updates `activeBackend`.
+
+`components/PatternDisplay.tsx` keeps `activeBackend === 'webgpu'` and shows the error overlay when `!webgpuAvailable`:
+
+```tsx
+{!useHTML && useWebGPU && !webgpuAvailable && (
+  <div className="error ...">
+    WebGPU not available — use <code>?renderer=webgl2</code> ...
+  </div>
+)}
+```
+
+There is a debug-panel `<select>` to switch renderers, but no automatic recovery.
+
+### 3. Related: `utils/deviceCapabilities.ts` already async-probes adapters
+
+`probeWebGPUAdapter()` in `deviceCapabilities.ts` performs a real `requestAdapter()` call for lite-mode heuristics, but renderer selection does not reuse this logic.
+
+---
+
+## Reproduction
+
+1. Open `https://test.1ink.us/xm-player/index.html` in a browser without a usable WebGPU adapter (Safari, Chrome with `--disable-gpu`, some headless/CI environments).
+2. Observe the red WebGPU error overlay; visualization is unusable.
+3. Reload with `?renderer=webgl2` — canvas initializes (separate data-pipeline issues may still apply).
+
+**Local repro (dev):** Temporarily stub `navigator.gpu.requestAdapter` to resolve `null` while leaving `'gpu' in navigator` true.
+
+---
+
+## Proposed Fix
+
+### Option A (recommended): Async probe at startup + cache result
+
+1. Add `probeWebGPUAdapter(): Promise<boolean>` to `rendererSelection.ts` (or reuse `deviceCapabilities.ts`).
+2. Run the probe once during app/renderer bootstrap before committing to `webgpu`.
+3. Cache the result in module scope or `sessionStorage` to avoid repeated adapter requests.
+4. Update `resolvePatternRenderer()` to accept a pre-probed flag, or expose `resolvePatternRendererAsync()`.
+
+### Option B: Runtime fallback on init failure
+
+In `useWebGPURender` catch/`!adapter` paths (or a `PatternDisplay` effect watching `webgpuAvailable`):
+
+```ts
+if (!webgpuAvailable && activeBackend === 'webgpu') {
+  const fallback = isWebGL2Available() ? 'webgl2' : 'html';
+  console.warn(`[Renderer] WebGPU init failed; auto-falling back to ${fallback}`);
+  setRendererOverride(fallback);
+  setActiveBackend(fallback);
+}
+```
+
+Guard against infinite loops (only fall back once per session).
+
+### Option C: Combine both
+
+- Sync fast path for obvious cases (`'gpu' not in navigator` → skip WebGPU immediately).
+- Async probe for the ambiguous case.
+- Runtime fallback as a safety net for shader/device errors after adapter success.
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `src/renderers/rendererSelection.ts` | Async WebGPU probe; optional cached result |
+| `components/PatternDisplay.tsx` | Auto-fallback effect; soften/remove hard error overlay when fallback succeeds |
+| `hooks/useWebGPURender.ts` | Optionally emit fallback event on init failure |
+| `utils/deviceCapabilities.ts` | Consolidate adapter probing (avoid duplication) |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Page loads a working visualization on browsers without WebGPU (Safari, older Chrome, GPU-disabled).
+- [ ] When `requestAdapter()` returns `null`, app auto-selects WebGL2 (if available) or HTML without URL params.
+- [ ] When WebGPU init fails after adapter success (shader error, device lost), app falls back once and logs a clear message.
+- [ ] Explicit `?renderer=webgpu` still attempts WebGPU first; fallback only when init fails (document behavior).
+- [ ] No infinite fallback loop between backends.
+- [ ] Debug panel renderer override still works.
+
+---
+
+## Testing Notes
+
+- Manual: Safari macOS/iOS, Chrome `--disable-gpu`, Firefox (no WebGPU).
+- CI: extend `scripts/smoke-test-webgpu.mjs` or add a `?renderer=webgl2` screenshot smoke path.
+- Regression: confirm WebGPU still selected on Chrome 113+ with working GPU.
+
+---
+
+## Related
+
+- Blocks full usability of #TBD (pattern data pipeline) on fallback backends.
+- `components/PatternDisplay.responsive.tsx` has parallel WebGPU init logic — keep in sync or consolidate.

--- a/.github/issues/issue-2-pattern-data-pipeline.md
+++ b/.github/issues/issue-2-pattern-data-pipeline.md
@@ -1,0 +1,227 @@
+## Summary
+
+On production (`https://test.1ink.us/xm-player/`), the default module (`4-mat_madness.mod`) loads over HTTP, but **pattern data never reaches any renderer**:
+
+- `?renderer=webgl2` — gray/blank canvas; status stuck at `Parsing "4-mat_madness.mod"…`
+- `?renderer=html` — `PatternSequencer` shows **"No pattern data available."** (`matrix` is `null`)
+
+This indicates a broken **parser worker → React state** pipeline, not a renderer-specific GPU bug.
+
+**Investigation date:** 2026-06-17
+
+---
+
+## Current Behavior
+
+| Stage | Expected | Observed |
+|-------|----------|----------|
+| Fetch `4-mat_madness.mod` | HTTP 200, ~115 KB | ✅ Success |
+| Main thread libopenmpt init | `window.libopenmptReady` resolves | ✅ (audio path may work) |
+| Parser worker spawned | `openmpt-parser.worker-*.js` loads | Worker posts `{type:"parse",...}` |
+| Worker response | `{type:"parsed", patternMatrices, metadata}` | ❌ Never arrives or empty |
+| `sequencerMatrix` state | First order matrix set | ❌ Stays `null` |
+| Status text | `Loaded "…"` | ❌ Stuck at `Parsing "…"…` |
+
+---
+
+## Architecture (expected flow)
+
+```
+useLibOpenMPT.processModuleData()
+  ├─ fileData.slice() → fileDataRef (main-thread copy retained)
+  ├─ new Worker(openmpt-parser.worker.ts, { type: 'module' })
+  ├─ postMessage({ type:'parse', fileData, fileName }, [fileData.buffer])  // transfers buffer
+  └─ await Promise on worker 'message'
+       ├─ type:'parsed' → setSequencerMatrix(patternMatrices[0])
+       └─ type:'error'   → setStatus(`Error: ${message}`)
+
+PatternDisplay / WebGL2 / HTML
+  └─ receive matrix prop from App.tsx ← sequencerMatrix
+```
+
+Key files:
+
+- `hooks/useLibOpenMPT.ts` — `processModuleData()` (lines ~213–341)
+- `workers/openmpt-parser.worker.ts` — off-thread parse via CDN libopenmpt
+- `components/PatternDisplay.tsx` — `matrix` prop drives all GPU backends
+- `components/PatternSequencer.tsx` — shows "No pattern data available." when `!matrix`
+
+---
+
+## Root Cause Hypotheses (ranked)
+
+### H1: Parser worker hangs or crashes silently (most likely)
+
+`processModuleData` creates a Promise that **only resolves on `message`** — no timeout, no `worker.onerror`, no `messageerror` handler:
+
+```ts
+const result = await new Promise<WorkerParseResult>((resolve) => {
+  const worker = workerRef.current!;
+  const handler = (e: MessageEvent<WorkerParseResult>) => {
+    worker.removeEventListener('message', handler);
+    resolve(e.data);
+  };
+  worker.addEventListener('message', handler);
+  worker.postMessage({ type: 'parse', fileData, fileName }, [fileData.buffer]);
+});
+```
+
+If the worker throws before `postMessage`, or WASM init hangs, the Promise never settles → status stuck at **Parsing…** forever.
+
+The worker loads libopenmpt independently via:
+
+```ts
+const response = await fetch('https://wasm.noahcohn.com/libmpt/libopenmptjs.js');
+const fn = new Function(cleanedScript);
+fn.call(globalThis);
+```
+
+This is fragile under strict cross-origin isolation (see H2).
+
+### H2: Production COEP `require-corp` vs dev `credentialless`
+
+| Environment | COEP header |
+|-------------|-------------|
+| Vite dev (`vite.config.ts`) | `credentialless` |
+| Production (`test.1ink.us`) | `require-corp` |
+
+Production is stricter. The parser worker must fetch:
+
+1. Its own script (`openmpt-parser.worker-*.js`)
+2. libopenmpt JS + WASM from CDN
+
+CDN currently serves `Cross-Origin-Resource-Policy: cross-origin` (verified 2026-06-17), which should pass `require-corp`. However:
+
+- WASM instantiation inside a **module worker** evaluated via `new Function()` may still fail depending on CORP/COEP/CORS of `.wasm` assets.
+- Any CORP regression on the CDN would break the worker while the main-thread `<script src=…>` path still works → explains "libopenmpt ready but no patterns".
+
+### H3: Worker module bundling / base-path mismatch
+
+Worker is created with:
+
+```ts
+new Worker(new URL('../workers/openmpt-parser.worker.ts', import.meta.url), { type: 'module' })
+```
+
+Under subdirectory deploy (`VITE_APP_BASE_PATH=/xm-player/`), a mis-resolved worker URL → 404 → silent hang if `onerror` is not wired.
+
+**Verify:** Network tab for `openmpt-parser.worker-*.js` status on production.
+
+### H4: Structured-clone / transfer issue (less likely)
+
+Main thread transfers `fileData.buffer` to the worker (intentional; a `fileDataCopy` is retained separately). Worker response is a plain object (no transferables). Unlikely to zero out `patternMatrices` unless worker sends `{type:'parsed', patternMatrices:[]}`.
+
+### H5: Race with renderer init (unlikely for HTML)
+
+HTML fallback reads the same `sequencerMatrix` React state. Stuck **Parsing…** means `processModuleData` never completed, not a renderer timing issue.
+
+---
+
+## Reproduction
+
+1. `https://test.1ink.us/xm-player/index.html?renderer=webgl2`
+2. Open DevTools → Network: confirm `4-mat_madness.mod` 200, worker JS 200.
+3. Console: look for `[processModuleData]` logs or worker errors.
+4. `?renderer=html` → "No pattern data available." confirms `sequencerMatrix === null`.
+5. Local: `VITE_APP_BASE_PATH=/xm-player/ npm run build && npm run preview` with COEP `require-corp` header emulation.
+
+---
+
+## Proposed Fix
+
+### 1. Instrument the pipeline
+
+Add staged logging (dev + opt-in prod via `?debug=parser`):
+
+```ts
+console.log('[Parser] posting to worker', fileName, fileData.byteLength);
+// worker: console.log('[Parser worker] WASM ready, orders:', numOrders);
+console.log('[Parser] received', result.type, result.patternMatrices?.length);
+```
+
+### 2. Harden `processModuleData` error handling
+
+```ts
+const PARSE_TIMEOUT_MS = 15_000;
+
+const result = await new Promise<WorkerParseResult>((resolve, reject) => {
+  const worker = workerRef.current!;
+  const timer = setTimeout(() => reject(new Error('Parser timed out')), PARSE_TIMEOUT_MS);
+
+  const onMessage = (e: MessageEvent<WorkerParseResult>) => { /* clearTimeout; resolve */ };
+  const onError = (e: ErrorEvent) => { /* clearTimeout; reject */ };
+
+  worker.addEventListener('message', onMessage);
+  worker.addEventListener('error', onError);
+  worker.postMessage(...);
+});
+```
+
+Wrap in try/catch; always transition status out of **Parsing…**.
+
+### 3. Validate worker response
+
+```ts
+if (result.type !== 'parsed' || !result.patternMatrices?.length) {
+  setStatus('Error: No pattern data in module');
+  console.error('[Parser] empty patternMatrices', result);
+  return;
+}
+```
+
+### 4. Consider unifying libopenmpt load path
+
+Options:
+
+- **A:** Parse on main thread after `libopenmptReady` (worker was optimization; main thread already loads libopenmpt for audio).
+- **B:** Pass initialized WASM exports to worker via `postMessage` instead of re-fetching CDN script in worker.
+- **C:** Host libopenmpt assets locally under `/xm-player/` with correct CORP headers.
+
+### 5. Align production COEP with dev
+
+If worker WASM fails only under `require-corp`, either:
+
+- Serve app with `credentialless` (matches `vite.config.ts`), or
+- Self-host all WASM/JS worker dependencies with `Cross-Origin-Resource-Policy: cross-origin`.
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `hooks/useLibOpenMPT.ts` | Timeout, `onerror`, response validation, logging |
+| `workers/openmpt-parser.worker.ts` | Error reporting, optional main-thread WASM sharing |
+| `vite.config.ts` / server config | Document or align COEP for production |
+| `deploy.py` / hosting | COEP header, asset cleanup |
+| `types.ts` | `WorkerParseResult` discriminated union guards |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Pattern data visible in WebGL2 within 3 s of page load on production URL.
+- [ ] HTML renderer shows pattern rows, not "No pattern data available."
+- [ ] Status transitions: `Fetching…` → `Parsing…` → `Loaded "…"` (or explicit error).
+- [ ] Worker 404/WASM/timeout failures surface a user-visible error within 15 s.
+- [ ] `sequencerMatrix` non-null for default `4-mat_madness.mod` after load.
+- [ ] Works with `VITE_APP_BASE_PATH=/xm-player/` on preview server.
+
+---
+
+## Debugging Checklist
+
+- [ ] Network: `openmpt-parser.worker-*.js` → 200
+- [ ] Network: CDN `libopenmptjs.js` + `.wasm` → 200 with CORP
+- [ ] Console: `crossOriginIsolated === true` on production
+- [ ] Console: `[processModuleData] Processing module:` appears
+- [ ] Console: worker `postMessage` response received
+- [ ] React DevTools: `sequencerMatrix` state after load
+
+---
+
+## Related
+
+- #TBD — Parser stuck at "Parsing…" (timeout/UX subset of this issue)
+- #TBD — WebGPU auto-fallback (renderer works but has no data)
+- Production COEP mismatch noted in deployment observations

--- a/.github/issues/issue-3-css-build-artifact.md
+++ b/.github/issues/issue-3-css-build-artifact.md
@@ -1,0 +1,159 @@
+## Summary
+
+The production build at `https://test.1ink.us/xm-player/` references a stylesheet with a **non-standard `.1iss` extension** and Apache serves it with an incorrect **`charset=utf-16`** header, despite the file content being UTF-8 CSS.
+
+**Impact:** Low severity (page appears styled in Chrome during investigation), but non-standard artifacts can break CSS parsing in strict browsers, confuse caching/CDN tooling, and indicate a corrupted or stale build pipeline output.
+
+**Investigation date:** 2026-06-17
+
+---
+
+## Evidence
+
+### Production `index.html`
+
+```html
+<link rel="stylesheet" crossorigin href="./assets/modplayer.1iss">
+```
+
+Note: source `index.html` in the repo references `./index.css` (dev entry). Vite build normally emits hashed `assets/index-*.css`.
+
+### HTTP headers (2026-06-17)
+
+```bash
+curl -sI https://test.1ink.us/xm-player/assets/modplayer.1iss
+# content-type: text/css; charset=utf-16
+# content-length: 39175
+```
+
+### File content
+
+`file` / `xxd` inspection shows standard UTF-8 Tailwind-style CSS (`:root { --background: … }`), not UTF-16 LE/BE BOM content.
+
+### Orphaned asset suspicion
+
+The current JS bundle (`index-ofcsgdds.js`) may not import this CSS file — styles might be inlined in JS or the `.1iss` file is a **stale artifact** from an older build while the active bundle uses a different CSS strategy.
+
+---
+
+## Root Cause Analysis
+
+### 1. Non-standard `.1iss` extension
+
+Likely causes:
+
+| Cause | Likelihood | Notes |
+|-------|------------|-------|
+| Corrupted content-hash in filename | Medium | Hash segment `.1iss` resembles garbled `.css` (character substitution) |
+| Custom `rollupOptions.output.assetFileNames` typo | Low | Current `vite.config.ts` has **no** `assetFileNames` override |
+| Manual/stale deploy artifact | High | `/assets/` contains 80+ historical `index-*.js` bundles (Nov 2025–Jun 2026) suggesting incomplete cleanup between deploys |
+| Third-party build tool rename | Low | No `.1iss` references in current repo source |
+
+The repo's current Vite config (`vite.config.ts`) uses defaults — a fresh `npm run build` should produce `dist/assets/index-<hash>.css`.
+
+### 2. `charset=utf-16` header
+
+Apache is mis-detecting encoding (possibly due to unusual filename/extension). Browsers may ignore the charset if no BOM is present, but this is spec-ambiguous and risky.
+
+### 3. Dev vs production CSS path
+
+| Context | CSS loading |
+|---------|-------------|
+| Dev | `<link href="./index.css">` processed by Vite + PostCSS/Tailwind |
+| Production | Extracted CSS chunk linked from built `index.html` |
+
+Verify post-build `dist/index.html` locally with `VITE_APP_BASE_PATH=/xm-player/ npm run build`.
+
+---
+
+## Reproduction
+
+1. `curl -s https://test.1ink.us/xm-player/index.html | grep stylesheet`
+2. `curl -sI https://test.1ink.us/xm-player/assets/modplayer.1iss`
+3. Compare with local build: `VITE_APP_BASE_PATH=/xm-player/ npm run build && cat dist/index.html | grep stylesheet`
+
+---
+
+## Proposed Fix
+
+### 1. Verify local build output
+
+```bash
+VITE_APP_BASE_PATH=/xm-player/ npm run build
+grep -E 'stylesheet|\.css' dist/index.html
+ls -la dist/assets/*.css
+```
+
+Confirm emitted extension is `.css` and `index.html` references match.
+
+### 2. Fix deploy pipeline
+
+- `deploy.py` zips entire `dist/` — ensure deploy **replaces** old assets or prunes stale `/assets/*` on server.
+- Add deploy step: delete remote `assets/` before upload, or use versioned directory per release.
+
+### 3. Fix Apache charset (server config)
+
+For `.css` files under `/xm-player/assets/`:
+
+```apache
+<FilesMatch "\.css$">
+  Header set Content-Type "text/css; charset=utf-8"
+</FilesMatch>
+```
+
+Or remove erroneous `AddCharset utf-16` if present for this vhost.
+
+### 4. Optional: explicit Vite asset naming
+
+If deterministic names are needed for debugging:
+
+```ts
+// vite.config.ts
+build: {
+  rollupOptions: {
+    output: {
+      assetFileNames: 'assets/[name]-[hash][extname]',
+    },
+  },
+},
+```
+
+(`[extname]` must remain literal — a typo here could cause the `.1iss` symptom.)
+
+### 5. Audit CSS inclusion
+
+Confirm Tailwind/CSS is extracted (not silently dropped). Check `dist/assets/*.css` size ≈ production 39 KB.
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `vite.config.ts` | Optional explicit `assetFileNames`; verify `cssCodeSplit` |
+| `deploy.py` | Prune stale assets on remote |
+| Server/Apache vhost | Correct `Content-Type` charset for CSS |
+| `index.css` / `postcss.config.js` | Only if CSS fails to emit |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Production stylesheet URL ends in `.css` (e.g. `assets/index-<hash>.css`).
+- [ ] `Content-Type: text/css; charset=utf-8` (or omit charset; no `utf-16`).
+- [ ] `index.html` `<link rel="stylesheet">` matches the CSS file present in the deployed bundle.
+- [ ] No orphaned `modplayer.1iss` (or equivalent stale CSS) after deploy.
+- [ ] Visual styling matches dev build (Tailwind theme variables, panel chrome, etc.).
+
+---
+
+## Additional Cleanup (same deploy pass)
+
+Production `/assets/` contains 80+ stale `index-*.js` bundles. Add retention policy (keep last N hashes) to reduce disk use and cache confusion. See deployment hygiene issue.
+
+---
+
+## Related
+
+- Deploy bundle uploads via `deploy.py` → `storage.noahcohn.com` → `test.1ink.us/xm-player/`
+- Tailwind content paths are intentionally narrow in `tailwind.config.js` — unrelated but affects CSS size

--- a/.github/issues/issue-4-parser-timeout-ux.md
+++ b/.github/issues/issue-4-parser-timeout-ux.md
@@ -1,0 +1,215 @@
+## Summary
+
+The status bar on production can remain stuck indefinitely at:
+
+> Parsing "4-mat_madness.mod"…
+
+with no success message, no error message, and no recovery path. This is a **UX/reliability gap** in the parser worker integration — distinct from but tightly coupled to the pattern-data pipeline failure.
+
+**Investigation date:** 2026-06-17
+
+---
+
+## Current Behavior
+
+1. `useLibOpenMPT` init completes → `isReady = true`.
+2. Default module effect fetches `4-mat_madness.mod` → calls `processModuleData()`.
+3. `setStatus('Parsing "${fileName}"…')` runs immediately.
+4. If the parser worker never responds, status **never updates** — no timeout, no spinner differentiation, no retry.
+
+Users cannot distinguish:
+
+- Slow WASM init (may take 10–25 s in worker)
+- Worker 404 / script error
+- COEP-blocked WASM fetch
+- Hung `onRuntimeInitialized` in worker
+
+---
+
+## Root Cause
+
+### 1. Promise without timeout or rejection path
+
+`hooks/useLibOpenMPT.ts` — `processModuleData()`:
+
+```ts
+setStatus(`Parsing "${fileName}"…`);
+
+const result = await new Promise<WorkerParseResult>((resolve) => {
+  const worker = workerRef.current!;
+  const handler = (e: MessageEvent<WorkerParseResult>) => {
+    worker.removeEventListener('message', handler);
+    resolve(e.data);
+  };
+  worker.addEventListener('message', handler);
+  worker.postMessage(
+    { type: 'parse', fileData, fileName },
+    [fileData.buffer]
+  );
+});
+```
+
+Problems:
+
+| Gap | Consequence |
+|-----|-------------|
+| Only `resolve`, never `reject` | Exceptions in setup don't propagate |
+| No `worker.addEventListener('error', …)` | Script load/syntax errors swallowed |
+| No `messageerror` handler | Structured-clone failures swallowed |
+| No timeout | Infinite **Parsing…** state |
+| Listener removed only on first message | Late duplicate messages ignored (minor) |
+
+### 2. Worker-side timeout exists only for WASM init
+
+`workers/openmpt-parser.worker.ts` has a 25 s `onRuntimeInitialized` timeout, but:
+
+- Network failure fetching CDN script throws → caught → posts `{type:'error'}` ✅
+- If `postMessage` from worker fails, main thread still hangs ❌
+- If worker script fails to load (404), main thread has no `error` listener ❌
+
+### 3. Status string contract is informal
+
+Status values are free-form strings (`setStatus(...)`). No enum for `{idle, fetching, parsing, loaded, error}`. UI cannot render differentiated states (spinner vs error vs success).
+
+### 4. Init path vs user load path share the same fragile promise
+
+Both default module load (`useEffect` at line ~945) and `loadModule()` call `processModuleData()` — same hang behavior for playlist uploads.
+
+---
+
+## Reproduction
+
+1. Open `https://test.1ink.us/xm-player/index.html` (any renderer).
+2. Wait >30 s — status remains **Parsing…**.
+3. **Simulate locally:** block `openmpt-parser.worker-*.js` in DevTools → permanent hang.
+4. **Simulate:** throttle network + block CDN WASM → hang or very long wait with no feedback.
+
+---
+
+## Proposed Fix
+
+### 1. Robust promise wrapper
+
+```ts
+function parseInWorker(
+  worker: Worker,
+  message: WorkerParseMessage,
+  transfer: Transferable[],
+  timeoutMs = 15_000,
+): Promise<WorkerParseResult> {
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(() => {
+      cleanup();
+      reject(new Error(`Parser timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const onMessage = (e: MessageEvent<WorkerParseResult>) => {
+      cleanup();
+      resolve(e.data);
+    };
+    const onError = (e: ErrorEvent) => {
+      cleanup();
+      reject(new Error(e.message || 'Parser worker error'));
+    };
+    const onMessageError = () => {
+      cleanup();
+      reject(new Error('Parser worker message deserialization failed'));
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      worker.removeEventListener('message', onMessage);
+      worker.removeEventListener('error', onError);
+      worker.removeEventListener('messageerror', onMessageError);
+    };
+
+    worker.addEventListener('message', onMessage);
+    worker.addEventListener('error', onError);
+    worker.addEventListener('messageerror', onMessageError);
+    worker.postMessage(message, transfer);
+  });
+}
+```
+
+### 2. Catch in `processModuleData`
+
+```ts
+try {
+  const result = await parseInWorker(worker, { type: 'parse', fileData, fileName }, [fileData.buffer]);
+  // existing success path
+} catch (err) {
+  const msg = err instanceof Error ? err.message : 'Parser failed';
+  console.error('[processModuleData]', err);
+  setStatus(`Error: ${msg}`);
+  return;
+}
+```
+
+### 3. Worker load verification at init
+
+When creating the worker, attach a permanent `error` listener that logs and sets `parserWorkerHealthy = false`.
+
+Optionally verify worker URL with `fetch(workerUrl, { method: 'HEAD' })` during app init (similar to `useWorkletLoader.verifyWorkletFile`).
+
+### 4. Progressive status feedback
+
+```ts
+setStatus(`Parsing "${fileName}"…`);
+// after 5s if still pending:
+setStatus(`Parsing "${fileName}"… (loading WASM)`);
+```
+
+Or expose `parsePhase: 'wasm' | 'patterns' | 'done'` for the Header component.
+
+### 5. Retry / fallback to main-thread parse
+
+If worker fails or times out, fall back to parsing on the main thread (libopenmpt already initialized for audio):
+
+```ts
+console.warn('[Parser] Worker failed; falling back to main-thread parse');
+await parseOnMainThread(fileDataCopy, fileName);
+```
+
+This provides resilience and unblocks users even if worker COEP issues persist.
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `hooks/useLibOpenMPT.ts` | `parseInWorker` helper, try/catch, status updates |
+| `workers/openmpt-parser.worker.ts` | Progress messages (`{type:'progress', stage:'wasm'}`) |
+| `components/Header.tsx` | Optional parse-phase UI |
+| `hooks/useWorkletLoader.ts` | Reuse HEAD-check pattern for worker URL |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Parsing resolves to **Loaded** or **Error: …** within 15 s (configurable).
+- [ ] Worker script 404 produces `Error: Parser worker failed` (not infinite hang).
+- [ ] Worker runtime exception surfaces message to status bar.
+- [ ] Default module load on production no longer stuck at **Parsing…** indefinitely.
+- [ ] User-initiated file load (`loadModule`) has same timeout behavior.
+- [ ] Console logs include correlation id / fileName for support debugging.
+
+---
+
+## Testing
+
+| Scenario | Expected status |
+|----------|-----------------|
+| Happy path | `Loaded "4-mat_madness"` (or module title) |
+| Block worker JS | `Error: Parser worker error` ≤15 s |
+| Invalid .mod bytes | `Error: Failed to load module (invalid format?)` |
+| CDN blocked | `Error: Failed to fetch libopenmpt JS: …` |
+| Timeout | `Error: Parser timed out after 15000ms` |
+
+---
+
+## Related
+
+- Parent/data issue: pattern matrices never reach `sequencerMatrix` (same root hang).
+- `useWorkletLoader` already implements worklet HEAD checks and diagnostics — mirror for parser worker.
+- Production COEP `require-corp` may trigger worker failures that this issue must surface clearly.

--- a/.github/issues/issue-5-deployment-hygiene.md
+++ b/.github/issues/issue-5-deployment-hygiene.md
@@ -1,0 +1,90 @@
+## Summary
+
+Non-blocking production hygiene issues observed during the 2026-06-17 investigation of `https://test.1ink.us/xm-player/`. These do not individually break the app but increase operational risk.
+
+---
+
+## 1. COEP header mismatch (dev vs production)
+
+| Environment | `Cross-Origin-Embedder-Policy` |
+|-------------|-------------------------------|
+| Vite dev (`vite.config.ts`) | `credentialless` |
+| Production Apache | `require-corp` |
+
+**Risk:** `credentialless` allows cross-origin scripts without `Cross-Origin-Resource-Policy`. `require-corp` blocks any resource lacking CORP/CORS/CORS-exempt credentials.
+
+Currently works because:
+
+- `libopenmptjs.js` CDN returns `Cross-Origin-Resource-Policy: cross-origin` ✅
+- esm.sh React importmap loads (verify CORP on each resource)
+
+**If CDN policy changes**, main-thread libopenmpt or parser worker WASM load could fail silently.
+
+**Recommendation:**
+
+- Document required CORP headers for all external dependencies.
+- Prefer self-hosting libopenmpt + WASM under `/xm-player/` with explicit CORP.
+- Align production COEP with dev (`credentialless`) **or** audit every cross-origin asset.
+
+---
+
+## 2. Stale asset accumulation in `/assets/`
+
+Production `/assets/` contains **80+** historical `index-*.js` bundles (dating to Nov 2025) plus orphaned CSS (`modplayer.1iss`).
+
+**Risk:**
+
+- Disk bloat on VPS
+- Users/agents/cache may reference old hashes
+- Debugging confusion (which bundle is live?)
+
+**Recommendation:**
+
+- `deploy.py` / server extract: **replace** `assets/` atomically per deploy, or
+- Retain only `index.html`-referenced hashes + `rm` older files
+- Add `deploy.py --prune` or server-side `find … -mtime +30 -delete`
+
+---
+
+## 3. External CDN dependency chain
+
+Load order on production:
+
+1. `index-ofcsgdds.js` (app bundle)
+2. `esm.sh` React importmap
+3. `wasm.noahcohn.com/libmpt/libopenmptjs.js` (main thread)
+4. Same CDN fetched again inside parser worker
+5. Audio worklet scripts under `/xm-player/worklets/`
+
+**Recommendation:**
+
+- Add `<link rel="preconnect" href="https://wasm.noahcohn.com">`
+- Add SRI (`integrity=`) for libopenmpt script if hash is stable
+- Consider vendoring libopenmpt into `public/` for offline/reproducible deploys
+
+---
+
+## 4. CSS possibly orphaned from active bundle
+
+`modplayer.1iss` is linked in `index.html` but may not correspond to the current JS entry's CSS graph. Verify whether styles are:
+
+- Loaded via `<link>` (expected Vite extract), or
+- Injected via JS `import './index.css'` in bundle
+
+Run `grep -r modplayer dist/` after local build.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Production COEP policy documented in `DEVELOPER_CONTEXT.md` or deploy README.
+- [ ] Deploy removes stale `assets/` not referenced by current `index.html`.
+- [ ] External dependency CORP requirements listed.
+- [ ] Optional: libopenmpt vendored for production.
+
+---
+
+## Related
+
+- CSS `.1iss` / charset issue
+- Parser worker CDN fetch failures under strict COEP


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds local copies of the expanded GitHub issue bodies created during the 2026-06-17 production investigation (`https://test.1ink.us/xm-player/`).

These drafts correspond to live issues:

- #273 — WebGPU init failure does not auto-fallback to WebGL2/HTML
- #274 — Pattern data never reaches renderers after parser worker
- #275 — Production stylesheet `.1iss` extension + wrong `utf-16` charset
- #276 — Parser status stuck at "Parsing…"
- #277 — Production deploy hygiene (COEP, stale assets, CDN)

## Why keep these in-repo?

- Preserves full RCA text, file references, and acceptance criteria alongside the codebase
- Useful as implementation checklists when fixing the linked issues
- Avoids losing detail if issue comments are edited on GitHub

## Files

- `.github/issues/issue-1-webgpu-fallback.md`
- `.github/issues/issue-2-pattern-data-pipeline.md`
- `.github/issues/issue-3-css-build-artifact.md`
- `.github/issues/issue-4-parser-timeout-ux.md`
- `.github/issues/issue-5-deployment-hygiene.md`

No runtime code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-451605a5-227a-46a7-afb2-8241016db9a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-451605a5-227a-46a7-afb2-8241016db9a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

