### PR TITLE
Fix subpath deploy load failures (API 404, matrix=null hang)

### DIFF
--- a/audio-worklet/diagnostics.ts
+++ b/audio-worklet/diagnostics.ts
@@ -5,6 +5,8 @@
  * Use these functions to troubleshoot worklet initialization failures.
  */
 
+import { detectRuntimeBase } from '../src/lib/paths';
+
 export interface WorkletDiagnostics {
   audioContextSupported: boolean;
   audioWorkletSupported: boolean;
@@ -37,7 +39,7 @@ export function getWorkletDiagnostics(workletUrl: string): WorkletDiagnostics {
     hasSharedArrayBuffer: typeof SharedArrayBuffer !== 'undefined',
     hardwareConcurrency: typeof navigator !== 'undefined' ? navigator.hardwareConcurrency || 0 : 0,
     userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown',
-    baseUrl: import.meta.env.BASE_URL,
+    baseUrl: detectRuntimeBase(),
     workletUrl,
     timestamp: new Date().toISOString(),
   };

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -105,3 +105,4 @@ Load the app: status should progress `Fetching` → `Parsing` → `Loaded` withi
 | `DEPLOY_TOKEN` | (see `deploy.py`) | Auth for storage.noahcohn.com |
 | `DEPLOY_CLEAN` | `1` | Set `0` to skip remote prune request |
 | `VITE_APP_BASE_PATH` | `/xm-player/` for production build | Asset URLs in `index.html` |
+| `VITE_STORAGE_API_URL` | `https://storage.noahcohn.com` (set in `build:xm-player`) | Library/shader API (`/api/songs`, `/api/shaders`) |

--- a/hooks/useLibOpenMPT.ts
+++ b/hooks/useLibOpenMPT.ts
@@ -53,6 +53,34 @@ const WORKLET_ROW_SMOOTHING = 0.88;
 // ScriptProcessor / direct lib query: near-instant follow
 const DIRECT_ROW_SMOOTHING = 0.96;
 
+function isLibReadyForParse(lib: LibOpenMPT): boolean {
+  return typeof lib._openmpt_module_create_from_memory2 === 'function';
+}
+
+function parseOnMainThread(
+  lib: LibOpenMPT,
+  fileData: Uint8Array,
+  fileName: string,
+): WorkerParseResponse {
+  parserLog('main-thread parse', fileName, fileData.byteLength);
+  const parsed = parseModuleWithLib(lib, fileData, fileName);
+  if (!parsed.patternMatrices.length) {
+    throw new Error('No pattern data in module');
+  }
+  console.log(
+    `[Parser] main-thread parse OK (${fileName}):`,
+    parsed.metadata.numOrders,
+    'orders,',
+    parsed.patternMatrices.length,
+    'matrices',
+  );
+  return {
+    type: 'parsed',
+    patternMatrices: parsed.patternMatrices,
+    metadata: parsed.metadata,
+  };
+}
+
 async function resolveParsedModule(
   lib: LibOpenMPT,
   worker: Worker | null,
@@ -62,6 +90,13 @@ async function resolveParsedModule(
   fileName: string,
   onParseProgress?: (stage: 'fetch' | 'wasm' | 'patterns') => void,
 ): Promise<WorkerParseResponse> {
+  // Main thread already has initialized libopenmpt from index.html — use it directly.
+  // The worker re-fetches WASM from CDN (slow, can fail under strict COEP/CORP).
+  if (isLibReadyForParse(lib)) {
+    onParseProgress?.('patterns');
+    return parseOnMainThread(lib, fileDataCopy, fileName);
+  }
+
   let workerResult: WorkerParseResponse | WorkerParseError | null = null;
 
   if (worker) {
@@ -96,23 +131,7 @@ async function resolveParsedModule(
     }
   }
 
-  parserLog('main-thread parse', fileName, fileDataCopy.byteLength);
-  const parsed = parseModuleWithLib(lib, fileDataCopy, fileName);
-  if (!parsed.patternMatrices.length) {
-    throw new Error('No pattern data in module');
-  }
-  console.log(
-    `[Parser] main-thread parse OK (${fileName}):`,
-    parsed.metadata.numOrders,
-    'orders,',
-    parsed.patternMatrices.length,
-    'matrices',
-  );
-  return {
-    type: 'parsed',
-    patternMatrices: parsed.patternMatrices,
-    metadata: parsed.metadata,
-  };
+  return parseOnMainThread(lib, fileDataCopy, fileName);
 }
 
 export function useLibOpenMPT(initialVolume: number = 0.4) {
@@ -333,9 +352,9 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     const fileDataCopy = fileData.slice();
     fileDataRef.current = fileDataCopy;
 
-    // Create / reuse the parser worker. If creation throws (404, CSP, MIME),
-    // mark it unhealthy and fall through to the main-thread parse.
-    if (!workerRef.current && parserWorkerHealthyRef.current) {
+    // Create parser worker only when main-thread lib is not yet ready (rare).
+    const useWorkerParse = !isLibReadyForParse(lib);
+    if (useWorkerParse && !workerRef.current && parserWorkerHealthyRef.current) {
       try {
         workerRef.current = createParserWorker((message) => {
           parserWorkerHealthyRef.current = false;
@@ -372,7 +391,7 @@ export function useLibOpenMPT(initialVolume: number = 0.4) {
     try {
       const parsed = await resolveParsedModule(
         lib,
-        parserWorkerHealthyRef.current ? workerRef.current : null,
+        useWorkerParse && parserWorkerHealthyRef.current ? workerRef.current : null,
         workerRef,
         fileData,
         fileDataCopy,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:worklet": "bash ./build-wasm.sh",
     "build:emcc": "bash scripts/build-wasm.sh",
     "build": "tsc && node --max-old-space-size=4096 node_modules/.bin/vite build",
-    "build:xm-player": "VITE_APP_BASE_PATH=/xm-player/ npm run build",
+    "build:xm-player": "VITE_APP_BASE_PATH=/xm-player/ VITE_STORAGE_API_URL=https://storage.noahcohn.com npm run build",
     "verify:build": "node scripts/verify-build.mjs",
     "build:xm-player:verify": "npm run build:xm-player && npm run verify:build",
     "preview": "vite preview",

--- a/utils/storageApi.ts
+++ b/utils/storageApi.ts
@@ -1,7 +1,15 @@
 import { z } from 'zod';
 import { detectRuntimeBase } from '../src/lib/paths';
 
-const storageBaseUrl = (import.meta.env.VITE_STORAGE_API_URL ?? '').trim().replace(/\/+$/, '');
+/** Production library API (storage_manager on Contabo). Dev uses Vite proxy when unset. */
+const PRODUCTION_STORAGE_API = 'https://storage.noahcohn.com';
+
+const storageBaseUrl = (() => {
+  const fromEnv = (import.meta.env.VITE_STORAGE_API_URL ?? '').trim().replace(/\/+$/, '');
+  if (fromEnv) return fromEnv;
+  if (import.meta.env.PROD) return PRODUCTION_STORAGE_API;
+  return '';
+})();
 
 const SongSchema = z.object({
   id: z.union([z.string(), z.number()]).optional(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes console errors and stuck loading when the app runs at `https://test.1ink.us/xm-player/`.

## Root causes

1. **`/api/songs` and `/api/shaders` 404** — production builds called relative `/xm-player/api/*` on the static host, but the library API lives on `https://storage.noahcohn.com`.
2. **`matrix=null` after module fetch** — the parser worker re-downloaded libopenmpt WASM from CDN (15s+ timeout) even though the main thread already had WASM initialized. Under strict COEP (`require-corp` on the live server) this path is slow and unreliable.
3. **Stale deploy on test.1ink.us** — live `index.html` still references `./assets/modplayer.1iss` (corrupt CSS) and `base: /` instead of `/xm-player/`. A fresh `npm run build:xm-player:verify` deploy is required.

## Changes

- **`utils/storageApi.ts`**: Production fallback to `https://storage.noahcohn.com` when `VITE_STORAGE_API_URL` is unset; dev still uses Vite `/api` proxy.
- **`package.json`**: `build:xm-player` now sets `VITE_STORAGE_API_URL=https://storage.noahcohn.com`.
- **`hooks/useLibOpenMPT.ts`**: Prefer main-thread parse when libopenmpt is ready; skip parser worker creation in the common case.
- **`audio-worklet/diagnostics.ts`**: Log `detectRuntimeBase()` instead of raw `import.meta.env.BASE_URL`.
- **`docs/DEPLOY.md`**: Document `VITE_STORAGE_API_URL`.

## Deploy steps

```bash
npm run build:xm-player:verify
python deploy.py --build
```

After deploy, verify:
- Status progresses `Fetching` → `Parsing` → `Loaded` within a few seconds
- No 404 on `storage.noahcohn.com/api/songs`
- `index.html` references `/xm-player/assets/index-*.css` (not `modplayer.1iss`)
- COEP header is `credentialless` (`.htaccess` in dist overrides server `require-corp`)

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build:xm-player:verify`
- [x] Storage API URL baked into dist bundle
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e37f2fcb-91a7-4b28-890b-ac4ee1f7d86d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e37f2fcb-91a7-4b28-890b-ac4ee1f7d86d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation with environment variable configuration for storage API URL.

* **Chores**
  * Updated build configuration to support storage API URL environment variable with fallback behavior.
  * Refactored internal code paths for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->