### PR TITLE
Fix production load failures: redeploy + COEP header override

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -3,8 +3,10 @@
 # COOP/COEP match Vite dev (credentialless) so WASM workers and CDN libopenmpt load.
 
 <IfModule mod_headers.c>
+  # Parent vhost may set require-corp; unset so credentialless wins (CDN libopenmpt, esm.sh).
+  Header always unset Cross-Origin-Embedder-Policy
   Header set Cross-Origin-Opener-Policy "same-origin"
-  Header set Cross-Origin-Embedder-Policy "credentialless"
+  Header always set Cross-Origin-Embedder-Policy "credentialless"
 
   <FilesMatch "\.css$">
     Header set Content-Type "text/css; charset=utf-8"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The live site at `https://test.1ink.us/xm-player/` was serving a **stale June 14 build** that caused incomplete page load:

- `index.html` referenced `./assets/modplayer.1iss` (corrupt CSS name, served as `charset=utf-16`)
- JS bundle (`index-ofcsgdds.js`) had `BASE_URL=/` and called `/api/songs` on `test.1ink.us` (404) instead of `https://storage.noahcohn.com`
- Parent Apache vhost injected `Cross-Origin-Embedder-Policy: require-corp`, conflicting with app `.htaccess`

## Fix

1. **Redeployed** current `main` via `npm run build:xm-player:verify` + `deploy.py`:
   - Correct stylesheet: `/xm-player/assets/index-CRjwTRxw.css`
   - Storage API baked to `https://storage.noahcohn.com/api/songs` and `/api/shaders`
   - Parser fast-path and subpath fixes from PR #281 now live

2. **`.htaccess` COEP override** — use `Header always unset/set` so `credentialless` wins over parent `require-corp` (verified: only one COEP header now)

## Verification

```bash
curl -s https://test.1ink.us/xm-player/index.html | grep stylesheet
# → /xm-player/assets/index-CRjwTRxw.css

curl -sI https://test.1ink.us/xm-player/index.html | grep -i cross-origin-embedder
# → credentialless (single value)

curl -s -H "Origin: https://test.1ink.us" https://storage.noahcohn.com/api/songs | head -c 80
# → JSON song list with CORS headers
```

No changes needed to `contabo_storage_manager` — CORS on `storage.noahcohn.com` already allows `test.1ink.us`.

## Note

Stale assets (`modplayer.1iss`, `index-ofcsgdds.js`) may still exist on disk until remote prune runs; they are no longer referenced by `index.html`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c842faef-71fc-4c65-8685-a1894a976b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c842faef-71fc-4c65-8685-a1894a976b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-origin page security settings so the app now consistently uses the intended embedder policy, even when a parent server has different defaults.
  * Preserved the existing same-origin opener policy to maintain current browser isolation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->