### PR TITLE
fix(build): load .env files in vite config so .env.production base pa…

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,19 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
-  // Use env-driven base for flexible deployment to different paths
+  // Load .env[.mode] files so VITE_-prefixed vars are available here in the
+  // config (Vite only injects them into import.meta.env, not process.env).
+  // Without this, .env.production's VITE_APP_BASE_PATH never reaches `base`.
+  const env = loadEnv(mode, process.cwd(), 'VITE_')
+
+  // Use env-driven base for flexible deployment to different paths.
+  // Precedence: inline/shell env var > .env[.mode] file > default '/'.
   // dev default: /
-  // deploy build: VITE_APP_BASE_PATH=/xm-player/ npm run build
-  const base = process.env.VITE_APP_BASE_PATH || '/'
-  const storageApiUrl = process.env.VITE_STORAGE_API_URL || 'http://localhost:8000'
+  // deploy build: VITE_APP_BASE_PATH=/xm-player/ npm run build (or .env.production)
+  const base = process.env.VITE_APP_BASE_PATH || env.VITE_APP_BASE_PATH || '/'
+  const storageApiUrl = process.env.VITE_STORAGE_API_URL || env.VITE_STORAGE_API_URL || 'http://localhost:8000'
   const storageProxyTarget = (() => {
     try {
       return new URL(storageApiUrl).origin


### PR DESCRIPTION
…th applies

vite.config.ts read process.env.VITE_APP_BASE_PATH, but Vite does not populate process.env from .env files (only import.meta.env via loadEnv). As a result .env.production's VITE_APP_BASE_PATH=/xm-player/ was a no-op: a plain 'npm run build' emitted base '/' and would have produced a broken subdirectory deploy (caught only by deploy.py's validate_build_base_path backstop).

Use loadEnv(mode, cwd, 'VITE_') and fall back through it. Precedence is preserved: inline/shell env var > .env[.mode] file > '/'. Verified:
- plain 'npm run build' now emits /xm-player/ base via .env.production
- build:xm-player (inline env) still correct
- dev mode (no .env.development) still '/'