### PR TITLE
patternv0.30b: trigger-only persistent note-on indicators

### DIFF
--- a/appConfig.ts
+++ b/appConfig.ts
@@ -27,7 +27,7 @@ export const SHADER_GROUPS = {
     { id: 'patternv0.38.wgsl', label: 'v0.38 (Glass)' },
     { id: 'patternv0.35_bloom.wgsl', label: 'v0.35 (Bloom)' },
     { id: 'patternv0.30.wgsl', label: 'v0.30 (Disc)' },
-    { id: 'patternv0.30b.wgsl', label: 'v0.30b (Disc Playhead)' },
+    { id: 'patternv0.30b.wgsl', label: 'v0.30b (Note-On Disc)' },
   ],
   VIDEO: [
     { id: 'patternv0.23.wgsl', label: 'v0.23 (Clouds)' },

--- a/public/shaders/patternv0.30b.wgsl
+++ b/public/shaders/patternv0.30b.wgsl
@@ -1,5 +1,5 @@
 // patternv0.30b.wgsl
-// v0.30 chrome disc aesthetic + v0.45b playhead-scrolled sustain (DURA/TRIG-001)
+// v0.30 chrome disc aesthetic + trigger-only note-on indicators with persistent glow (DURA/TRIG-001)
 
 struct Uniforms {
   numRows: u32,
@@ -28,10 +28,9 @@ const NOTE_MIN: u32     = 1u;
 const NOTE_MAX: u32     = 119u;
 const NOTE_OFF_MIN: u32 = 120u;
 
-// Sustain tuning (v0.45b)
-const SUSTAIN_GLOW: f32        = 0.45;
+// Sustain tuning — trigger cells stay lit for full note duration
 const TRIGGER_FLASH_BOOST: f32 = 1.4;
-const NOTE_AGE_TOLERANCE: f32  = 0.5;
+const NOTE_AGE_TOLERANCE: f32  = 0.6;
 const MIN_FADE_ROWS: f32       = 2.0;
 const MAX_FADE_ROWS: f32       = 6.0;
 const FADE_WINDOW_PCT: f32     = 0.30;
@@ -296,37 +295,37 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     let ch = channels[in.channel];
     let isMuted = (ch.isMuted == 1u);
 
-    // Playhead-scrolled sustain (v0.45b logic)
-    var sustainGlow = 0.0;
+    // Trigger-only persistent note-on (no duration-fill lines on sustain steps)
     var isTrigger = false;
-    var isSustain = false;
+    var noteActive = false;
+    var noteFade = 1.0;
 
     if (hasNote) {
       let dInfo = unpackDurationInfo(in.packedA, in.packedB);
       let isRealNoteOff = dInfo.isNoteOff || note >= NOTE_OFF_MIN;
       isTrigger = dInfo.isTrigger && !isRealNoteOff;
-      isSustain = dInfo.rowOffset > 0u && !isRealNoteOff && !dInfo.isTrigger;
 
-      let durationF = f32(dInfo.duration);
-      let noteRelativeAge = delta + f32(dInfo.rowOffset);
-      let isCurrentNote = abs(noteRelativeAge - ch.noteAge) < NOTE_AGE_TOLERANCE;
+      if (isTrigger) {
+        let durationF = f32(dInfo.duration);
+        let noteRelativeAge = delta + f32(dInfo.rowOffset);
+        noteActive = (noteRelativeAge >= 0.0 && noteRelativeAge < durationF) &&
+                     (abs(noteRelativeAge - ch.noteAge) < NOTE_AGE_TOLERANCE);
 
-      if ((isTrigger || isSustain) && durationF > 0.0 && noteRelativeAge >= 0.0 && noteRelativeAge < durationF && isCurrentNote) {
-        sustainGlow = select(1.0, SUSTAIN_GLOW, isSustain);
-
-        let fadeWindow = clamp(durationF * FADE_WINDOW_PCT, MIN_FADE_ROWS, MAX_FADE_ROWS);
-        let fadeStart = durationF - fadeWindow;
-        if (noteRelativeAge > fadeStart) {
-          let fadeT = (noteRelativeAge - fadeStart) / fadeWindow;
-          sustainGlow *= smoothstep(1.0, 0.0, fadeT);
+        if (noteActive && durationF > 0.0) {
+          let fadeWindow = clamp(durationF * FADE_WINDOW_PCT, MIN_FADE_ROWS, MAX_FADE_ROWS);
+          let fadeStart = durationF - fadeWindow;
+          if (noteRelativeAge > fadeStart) {
+            let fadeT = (noteRelativeAge - fadeStart) / fadeWindow;
+            noteFade = smoothstep(1.0, 0.0, fadeT);
+          }
         }
       }
     }
 
-    // COMPONENT 1: ACTIVITY LIGHT — only when note is actively sounding
+    // COMPONENT 1: ACTIVITY LIGHT — lit while this trigger's note is sounding
     let topUV = btnUV - vec2(0.5, 0.16);
     let topSize = vec2(0.20, 0.20);
-    let topActive = (sustainGlow > 0.0 || (isTrigger && ch.trigger > 0u && abs(delta) < 0.5)) && !isMuted;
+    let topActive = (isTrigger && noteActive && !isMuted);
     let topColor = vec3(0.0, 0.9, 1.0);
 
     let topLed = drawChromeIndicator(topUV, topSize, topColor, topActive, aa);
@@ -335,28 +334,25 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
       finalColor += topColor * topLed.a * 0.5;
     }
 
-    // COMPONENT 2: MAIN NOTE LIGHT
+    // COMPONENT 2: MAIN NOTE LIGHT — trigger cells only, persistent for note duration
     let mainUV = btnUV - vec2(0.5, 0.5);
     let mainSize = vec2(0.55, 0.45);
 
     var noteColor = vec3(0.2);
     var lightAmount = 0.0;
 
-    if (hasNote) {
+    if (isTrigger && noteActive) {
       let pitchHue = pitchClassFromNote(note);
       let baseColor = neonPalette(pitchHue);
       let instBand = inst & 15u;
       let instBright = 0.8 + (select(0.0, f32(instBand) / 15.0, instBand > 0u)) * 0.2;
       noteColor = baseColor * instBright;
 
-      lightAmount = sustainGlow * 0.85;
+      lightAmount = 0.92 * noteFade;
 
-      // Trigger flash at playhead only
-      if (isTrigger && abs(delta) < 0.5) {
-        lightAmount += TRIGGER_FLASH_BOOST * 0.35;
-        if (ch.trigger > 0u) {
-          lightAmount += TRIGGER_FLASH_BOOST * 0.45 * clamp(ch.volume, 0.0, 1.2);
-        }
+      // Extra flash when playhead hits the starting step
+      if (abs(delta) < 0.5 && ch.trigger > 0u) {
+        lightAmount += TRIGGER_FLASH_BOOST * 0.6 * clamp(ch.volume, 0.0, 1.2);
       }
 
       if (isMuted) { lightAmount *= 0.2; }
@@ -392,11 +388,6 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
 
     let botLed = drawChromeIndicator(botUV, botSize, effColor, isEffOn, aa);
     finalColor = mix(finalColor, botLed.rgb, botLed.a);
-
-    // COMPONENT 4: PLAYHEAD GLANCE
-    if (onPlayhead) {
-      finalColor += vec3(0.15, 0.2, 0.25) * housingMask * 0.4;
-    }
   }
 
   if (housingMask < 0.5) {

--- a/shaders/patternv0.30b.wgsl
+++ b/shaders/patternv0.30b.wgsl
@@ -1,5 +1,5 @@
 // patternv0.30b.wgsl
-// v0.30 chrome disc aesthetic + v0.45b playhead-scrolled sustain (DURA/TRIG-001)
+// v0.30 chrome disc aesthetic + trigger-only note-on indicators with persistent glow (DURA/TRIG-001)
 
 struct Uniforms {
   numRows: u32,
@@ -28,10 +28,9 @@ const NOTE_MIN: u32     = 1u;
 const NOTE_MAX: u32     = 119u;
 const NOTE_OFF_MIN: u32 = 120u;
 
-// Sustain tuning (v0.45b)
-const SUSTAIN_GLOW: f32        = 0.45;
+// Sustain tuning — trigger cells stay lit for full note duration
 const TRIGGER_FLASH_BOOST: f32 = 1.4;
-const NOTE_AGE_TOLERANCE: f32  = 0.5;
+const NOTE_AGE_TOLERANCE: f32  = 0.6;
 const MIN_FADE_ROWS: f32       = 2.0;
 const MAX_FADE_ROWS: f32       = 6.0;
 const FADE_WINDOW_PCT: f32     = 0.30;
@@ -296,37 +295,37 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
     let ch = channels[in.channel];
     let isMuted = (ch.isMuted == 1u);
 
-    // Playhead-scrolled sustain (v0.45b logic)
-    var sustainGlow = 0.0;
+    // Trigger-only persistent note-on (no duration-fill lines on sustain steps)
     var isTrigger = false;
-    var isSustain = false;
+    var noteActive = false;
+    var noteFade = 1.0;
 
     if (hasNote) {
       let dInfo = unpackDurationInfo(in.packedA, in.packedB);
       let isRealNoteOff = dInfo.isNoteOff || note >= NOTE_OFF_MIN;
       isTrigger = dInfo.isTrigger && !isRealNoteOff;
-      isSustain = dInfo.rowOffset > 0u && !isRealNoteOff && !dInfo.isTrigger;
 
-      let durationF = f32(dInfo.duration);
-      let noteRelativeAge = delta + f32(dInfo.rowOffset);
-      let isCurrentNote = abs(noteRelativeAge - ch.noteAge) < NOTE_AGE_TOLERANCE;
+      if (isTrigger) {
+        let durationF = f32(dInfo.duration);
+        let noteRelativeAge = delta + f32(dInfo.rowOffset);
+        noteActive = (noteRelativeAge >= 0.0 && noteRelativeAge < durationF) &&
+                     (abs(noteRelativeAge - ch.noteAge) < NOTE_AGE_TOLERANCE);
 
-      if ((isTrigger || isSustain) && durationF > 0.0 && noteRelativeAge >= 0.0 && noteRelativeAge < durationF && isCurrentNote) {
-        sustainGlow = select(1.0, SUSTAIN_GLOW, isSustain);
-
-        let fadeWindow = clamp(durationF * FADE_WINDOW_PCT, MIN_FADE_ROWS, MAX_FADE_ROWS);
-        let fadeStart = durationF - fadeWindow;
-        if (noteRelativeAge > fadeStart) {
-          let fadeT = (noteRelativeAge - fadeStart) / fadeWindow;
-          sustainGlow *= smoothstep(1.0, 0.0, fadeT);
+        if (noteActive && durationF > 0.0) {
+          let fadeWindow = clamp(durationF * FADE_WINDOW_PCT, MIN_FADE_ROWS, MAX_FADE_ROWS);
+          let fadeStart = durationF - fadeWindow;
+          if (noteRelativeAge > fadeStart) {
+            let fadeT = (noteRelativeAge - fadeStart) / fadeWindow;
+            noteFade = smoothstep(1.0, 0.0, fadeT);
+          }
         }
       }
     }
 
-    // COMPONENT 1: ACTIVITY LIGHT — only when note is actively sounding
+    // COMPONENT 1: ACTIVITY LIGHT — lit while this trigger's note is sounding
     let topUV = btnUV - vec2(0.5, 0.16);
     let topSize = vec2(0.20, 0.20);
-    let topActive = (sustainGlow > 0.0 || (isTrigger && ch.trigger > 0u && abs(delta) < 0.5)) && !isMuted;
+    let topActive = (isTrigger && noteActive && !isMuted);
     let topColor = vec3(0.0, 0.9, 1.0);
 
     let topLed = drawChromeIndicator(topUV, topSize, topColor, topActive, aa);
@@ -335,28 +334,25 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
       finalColor += topColor * topLed.a * 0.5;
     }
 
-    // COMPONENT 2: MAIN NOTE LIGHT
+    // COMPONENT 2: MAIN NOTE LIGHT — trigger cells only, persistent for note duration
     let mainUV = btnUV - vec2(0.5, 0.5);
     let mainSize = vec2(0.55, 0.45);
 
     var noteColor = vec3(0.2);
     var lightAmount = 0.0;
 
-    if (hasNote) {
+    if (isTrigger && noteActive) {
       let pitchHue = pitchClassFromNote(note);
       let baseColor = neonPalette(pitchHue);
       let instBand = inst & 15u;
       let instBright = 0.8 + (select(0.0, f32(instBand) / 15.0, instBand > 0u)) * 0.2;
       noteColor = baseColor * instBright;
 
-      lightAmount = sustainGlow * 0.85;
+      lightAmount = 0.92 * noteFade;
 
-      // Trigger flash at playhead only
-      if (isTrigger && abs(delta) < 0.5) {
-        lightAmount += TRIGGER_FLASH_BOOST * 0.35;
-        if (ch.trigger > 0u) {
-          lightAmount += TRIGGER_FLASH_BOOST * 0.45 * clamp(ch.volume, 0.0, 1.2);
-        }
+      // Extra flash when playhead hits the starting step
+      if (abs(delta) < 0.5 && ch.trigger > 0u) {
+        lightAmount += TRIGGER_FLASH_BOOST * 0.6 * clamp(ch.volume, 0.0, 1.2);
       }
 
       if (isMuted) { lightAmount *= 0.2; }
@@ -392,11 +388,6 @@ fn fs(in: VertexOut) -> @location(0) vec4<f32> {
 
     let botLed = drawChromeIndicator(botUV, botSize, effColor, isEffOn, aa);
     finalColor = mix(finalColor, botLed.rgb, botLed.a);
-
-    // COMPONENT 4: PLAYHEAD GLANCE
-    if (onPlayhead) {
-      finalColor += vec3(0.15, 0.2, 0.25) * housingMask * 0.4;
-    }
   }
 
   if (housingMask < 0.5) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `patternv0.30b.wgsl` so note lighting matches the intended chrome-disc behavior:

- **Trigger cells only** — only the starting step of each note gets the colored main pad / activity LED; sustain/duration-fill steps no longer glow as colored lines.
- **Persistent glow** — trigger indicators stay lit for the full note duration (using duration metadata + `channels[].noteAge`), with a gentle fade near note end.
- **No playhead housing tint** — removed COMPONENT 4 playhead glance highlight on pattern rows.
- **Trigger flash** — extra brightness when the playhead hits the starting step and `ch.trigger` is active.

Shader label in the picker updated to **v0.30b (Note-On Disc)**.

## Files changed

- `shaders/patternv0.30b.wgsl`
- `public/shaders/patternv0.30b.wgsl` (synced copy)
- `appConfig.ts` (label)

## Test plan

- [ ] Select **v0.30b (Note-On Disc)** in the shader picker
- [ ] Load a module with short stabs and long sustained notes
- [ ] Confirm only trigger steps show colored chrome pads (no filled arcs on intermediate steps)
- [ ] Confirm trigger pads stay lit while the note is sounding, then fade out
- [ ] Confirm no extra row-wide housing tint follows the playhead
- [ ] Confirm outer indicator ring (channel 0) still tracks playhead position
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e44a739-712a-42b6-a44f-7c09fa4ff33e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e44a739-712a-42b6-a44f-7c09fa4ff33e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated one circular shader option label from “Disc Playhead” to “Note-On Disc.”
  * Changed the visual behavior of the note-on display to use trigger-based lighting with a persistent glow.

* **Bug Fixes**
  * Refined note lighting so it stays aligned with active notes more consistently.
  * Removed the old playhead-based glow effect for a cleaner, more focused visual state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->